### PR TITLE
adding fix for Query adaption

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
@@ -21,6 +21,7 @@ import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
+import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
 import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 import com.google.common.base.Function;
@@ -46,13 +47,13 @@ public class CheckAndMutateUtil {
   // them (which they shouldn't since we built the filter), throw an exception.
   private static final ReadHooks UNSUPPORTED_READ_HOOKS = new ReadHooks() {
     @Override
-    public void composePreSendHook(Function<ReadRowsRequest, ReadRowsRequest> newHook) {
+    public void composePreSendHook(Function<Query, Query> newHook) {
       throw new IllegalStateException(
           "We built a bad Filter for conditional mutation.");
     }
 
     @Override
-    public ReadRowsRequest applyPreSendHook(ReadRowsRequest readRowsRequest) {
+    public void applyPreSendHook(Query query) {
       throw new UnsupportedOperationException(
           "We built a bad Filter for conditional mutation.");
     }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -20,6 +20,7 @@ import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.MutationApi;
+import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.common.annotations.VisibleForTesting;
@@ -169,27 +170,29 @@ public class HBaseRequestAdapter {
   /**
    * <p>adapt.</p>
    *
-   * @param get a {@link org.apache.hadoop.hbase.client.Get} object.
-   * @return a {@link com.google.bigtable.v2.ReadRowsRequest} object.
+   * @param get a {@link Get} object.
+   * @return a {@link ReadRowsRequest} object.
    */
   public ReadRowsRequest adapt(Get get) {
     ReadHooks readHooks = new DefaultReadHooks();
-    ReadRowsRequest.Builder builder = Adapters.GET_ADAPTER.adapt(get, readHooks);
-    builder.setTableName(getTableNameString());
-    return readHooks.applyPreSendHook(builder.build());
+    Query query = Query.create(bigtableTableName.getTableId());
+    Adapters.GET_ADAPTER.adapt(get, readHooks, query);
+    readHooks.applyPreSendHook(query);
+    return query.toProto(requestContext);
   }
 
   /**
    * <p>adapt.</p>
    *
-   * @param scan a {@link org.apache.hadoop.hbase.client.Scan} object.
-   * @return a {@link com.google.bigtable.v2.ReadRowsRequest} object.
+   * @param scan a {@link Scan} object.
+   * @return a {@link ReadRowsRequest} object.
    */
   public ReadRowsRequest adapt(Scan scan) {
     ReadHooks readHooks = new DefaultReadHooks();
-    ReadRowsRequest.Builder builder = Adapters.SCAN_ADAPTER.adapt(scan, readHooks);
-    builder.setTableName(getTableNameString());
-    return readHooks.applyPreSendHook(builder.build());
+    Query query = Query.create(bigtableTableName.getTableId());
+    Adapters.SCAN_ADAPTER.adapt(scan, readHooks, query);
+    readHooks.applyPreSendHook(query);
+    return query.toProto(requestContext);
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PageFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PageFilterAdapter.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
+import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 
@@ -43,13 +44,12 @@ public class PageFilterAdapter extends TypedFilterAdapterBase<PageFilter> {
   @Override
   public Filter adapt(FilterAdapterContext context, PageFilter filter) throws IOException {
     final long pageSize = filter.getPageSize();
-    context.getReadHooks().composePreSendHook(new Function<ReadRowsRequest, ReadRowsRequest>() {
+    context.getReadHooks().composePreSendHook(new Function<Query, Query>() {
       @Override
-      public ReadRowsRequest apply(ReadRowsRequest request) {
-        return request.toBuilder().setRowsLimit(pageSize).build();
+      public Query apply(Query query) {
+        return query.limit(pageSize);
       }
     });
-    // This filter cannot be translated to a RowFilter, all logic is done as a read hook.
     return null;
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PageFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/PageFilterAdapter.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
-import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.common.base.Function;
@@ -50,6 +49,7 @@ public class PageFilterAdapter extends TypedFilterAdapterBase<PageFilter> {
         return query.limit(pageSize);
       }
     });
+    // This filter cannot be translated to a RowFilter, all logic is done as a read hook.
     return null;
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampRangeFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampRangeFilterAdapter.java
@@ -20,7 +20,7 @@ import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
 import com.google.cloud.bigtable.hbase.filter.TimestampRangeFilter;
 
 /**
- * Converts a {@link TimestampRangeFilter} into a Cloud Bigtable {@link Filter}.
+ * Converts a {@link TimestampRangeFilter} into a Cloud Bigtable {@link RowFilter}.
  */
 public class TimestampRangeFilterAdapter extends TypedFilterAdapterBase<TimestampRangeFilter> {
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/DefaultReadHooks.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/DefaultReadHooks.java
@@ -15,27 +15,27 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.read;
 
-import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 
 /**
- * Default implementation of {@link com.google.cloud.bigtable.hbase.adapters.read.ReadHooks}.
+ * Default implementation of {@link ReadHooks}.
  *
  * @author sduskis
  * @version $Id: $Id
  */
 public class DefaultReadHooks implements ReadHooks {
-  private Function<ReadRowsRequest, ReadRowsRequest> preSendHook = Functions.identity();
+  private Function<Query, Query> preSendHook = Functions.identity();
   /** {@inheritDoc} */
   @Override
-  public void composePreSendHook(Function<ReadRowsRequest, ReadRowsRequest> newHook) {
+  public void composePreSendHook(Function<Query, Query> newHook) {
     preSendHook = Functions.compose(newHook, preSendHook);
   }
 
   /** {@inheritDoc} */
   @Override
-  public ReadRowsRequest applyPreSendHook(ReadRowsRequest readRowsRequest) {
-    return preSendHook.apply(readRowsRequest);
+  public void applyPreSendHook(Query query) {
+    preSendHook.apply(query);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/GetAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/GetAdapter.java
@@ -15,8 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.read;
 
-import com.google.bigtable.v2.ReadRowsRequest;
-import com.google.bigtable.v2.RowSet;
+import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Get;
@@ -25,7 +24,7 @@ import org.apache.hadoop.hbase.filter.FilterList;
 import org.apache.hadoop.hbase.filter.KeyOnlyFilter;
 
 /**
- * A Get adapter that transform the Get into a ReadRowsRequest using the proto-based
+ * A {@link Get} adapter that transform the Get into a {@link Query} using the proto-based
  * filter language.
  *
  * @author sduskis
@@ -47,7 +46,7 @@ public class GetAdapter implements ReadOperationAdapter<Get> {
   /**
    * <p>Constructor for GetAdapter.</p>
    *
-   * @param scanAdapter a {@link com.google.cloud.bigtable.hbase.adapters.read.ScanAdapter} object.
+   * @param scanAdapter a {@link ScanAdapter} object.
    */
   public GetAdapter(ScanAdapter scanAdapter) {
     this.scanAdapter = scanAdapter;
@@ -55,12 +54,12 @@ public class GetAdapter implements ReadOperationAdapter<Get> {
 
   /** {@inheritDoc} */
   @Override
-  public ReadRowsRequest.Builder adapt(Get operation, ReadHooks readHooks) {
+  public void adapt(Get operation, ReadHooks readHooks, Query query) {
     Scan operationAsScan = new Scan(addKeyOnlyFilter(operation));
     scanAdapter.throwIfUnsupportedScan(operationAsScan);
-    return ReadRowsRequest.newBuilder()
-        .setFilter(scanAdapter.buildFilter(operationAsScan, readHooks).toProto())
-        .setRows(RowSet.newBuilder().addRowKeys(ByteString.copyFrom(operation.getRow())));
+
+    query.filter(scanAdapter.buildFilter(operationAsScan, readHooks))
+        .rowKey(ByteString.copyFrom(operation.getRow()));
   }
 
   private Get addKeyOnlyFilter(Get get) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ReadHooks.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ReadHooks.java
@@ -15,11 +15,11 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.read;
 
-import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.common.base.Function;
 
 /**
- * Hooks for modifying a ReadRowsRequest before being sent to Cloud Bigtable.
+ * Hooks for modifying a {@link Query} before being sent to Cloud Bigtable.
  *
  * Note that it is expected that this will be extended to include post-read
  * hooks to transform Rows when appropriate.
@@ -30,17 +30,16 @@ import com.google.common.base.Function;
 public interface ReadHooks {
 
   /**
-   * Add a Function that will modify the ReadRowsRequest before it is sent to Cloud Bigtable.
+   * Add a {@link Function} that will modify the {@link Query} before it is sent to Cloud Bigtable.
    *
-   * @param newHook a {@link com.google.common.base.Function} object.
+   * @param newHook a {@link Function} object.
    */
-  void composePreSendHook(Function<ReadRowsRequest, ReadRowsRequest> newHook);
+  void composePreSendHook(Function<Query, Query> newHook);
 
   /**
    * Apply all pre-send hooks to the given request.
    *
-   * @param readRowsRequest a {@link com.google.bigtable.v2.ReadRowsRequest} object.
-   * @return a {@link com.google.bigtable.v2.ReadRowsRequest} object.
+   * @param query a {@link Query} object.
    */
-  ReadRowsRequest applyPreSendHook(ReadRowsRequest readRowsRequest);
+  void applyPreSendHook(Query query);
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ReadOperationAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ReadOperationAdapter.java
@@ -15,8 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.read;
 
-import com.google.bigtable.v2.ReadRowsRequest;
-
+import com.google.cloud.bigtable.data.v2.models.Query;
 import org.apache.hadoop.hbase.client.Operation;
 
 /**
@@ -30,8 +29,8 @@ public interface ReadOperationAdapter<T extends Operation> {
    * <p>adapt.</p>
    *
    * @param request a T object.
-   * @param readHooks a {@link com.google.cloud.bigtable.hbase.adapters.read.ReadHooks} object.
-   * @return a {@link com.google.bigtable.v2.ReadRowsRequest.Builder} object.
+   * @param readHooks a {@link ReadHooks} object.
+   * @param query a  {@link Query} object.
    */
-  ReadRowsRequest.Builder adapt(T request, ReadHooks readHooks);
+  void adapt(T request, ReadHooks readHooks, Query query);
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
@@ -17,9 +17,9 @@ package com.google.cloud.bigtable.hbase.adapters.read;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
-import com.google.bigtable.v2.ReadRowsRequest;
-import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.RowSet;
 import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.data.v2.models.Filters.ChainFilter;
@@ -32,6 +32,7 @@ import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapterContext;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.base.Optional;
 import com.google.common.collect.RangeSet;
+import com.google.common.collect.TreeRangeSet;
 import com.google.protobuf.ByteString;
 
 import org.apache.hadoop.hbase.client.Scan;
@@ -43,7 +44,7 @@ import java.util.Map;
 import java.util.NavigableSet;
 
 /**
- * An adapter for Scan operation that makes use of the proto filter language.
+ * An adapter for {@link Scan} operation that makes use of the proto filter language.
  *
  * @author sduskis
  * @version $Id: $Id
@@ -82,7 +83,7 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
   /**
    * <p>Constructor for ScanAdapter.</p>
    *
-   * @param filterAdapter a {@link com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter} object.
+   * @param filterAdapter a {@link FilterAdapter} object.
    */
   public ScanAdapter(FilterAdapter filterAdapter, RowRangeAdapter rowRangeAdapter) {
     this.filterAdapter = filterAdapter;
@@ -92,7 +93,7 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
   /**
    * <p>throwIfUnsupportedScan.</p>
    *
-   * @param scan a {@link org.apache.hadoop.hbase.client.Scan} object.
+   * @param scan a {@link Scan} object.
    */
   public void throwIfUnsupportedScan(Scan scan) {
     if (scan.getFilter() != null) {
@@ -106,11 +107,11 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
   }
 
   /**
-   * Given a Scan, build a RowFilter that include matching columns
+   * Given a {@link Scan}, build a {@link Filters.Filter} that include matching columns
    *
-   * @param scan a {@link org.apache.hadoop.hbase.client.Scan} object.
-   * @param hooks a {@link com.google.cloud.bigtable.hbase.adapters.read.ReadHooks} object.
-   * @return a {@link com.google.bigtable.v2.RowFilter} object.
+   * @param scan a {@link Scan} object.
+   * @param hooks a {@link ReadHooks} object.
+   * @return a {@link Filters.Filter} object.
    */
   public Filters.Filter buildFilter(Scan scan, ReadHooks hooks) {
     ChainFilter chain = FILTERS.chain();
@@ -137,60 +138,46 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
 
   /** {@inheritDoc} */
   @Override
-  public ReadRowsRequest.Builder adapt(Scan scan, ReadHooks readHooks) {
+  public void adapt(Scan scan, ReadHooks readHooks, Query query) {
     throwIfUnsupportedScan(scan);
 
-    ReadRowsRequest.Builder requestBuilder = ReadRowsRequest.newBuilder()
-        .setRows(toRowSet(scan))
-        .setFilter(buildFilter(scan, readHooks).toProto());
+    toByteStringRange(scan, query);
+    query.filter(buildFilter(scan, readHooks));
 
     if (LIMIT_AVAILABLE && scan.getLimit() > 0) {
-      requestBuilder.setRowsLimit(scan.getLimit());
+      query.limit(scan.getLimit());
     }
-
-    return requestBuilder;
   }
 
-  private RowSet toRowSet(Scan scan) {
-    RowSet rowSet = getRowSet(scan);
-    return narrowRowSet(rowSet, scan.getFilter());
+  private void toByteStringRange(Scan scan, Query query) {
+    RangeSet<RowKeyWrapper> rangeSet = narrowRange(getRangeSet(scan), scan.getFilter());
+    rowRangeAdapter.rangeSetToByteStringRange(rangeSet, query);
   }
 
-  private RowSet getRowSet(Scan scan) {
+  private RangeSet<RowKeyWrapper> getRangeSet(Scan scan) {
     if (scan instanceof BigtableExtendedScan) {
-      return ((BigtableExtendedScan) scan).getRowSet();
+      RowSet rowSet = ((BigtableExtendedScan) scan).getRowSet();
+      return rowRangeAdapter.rowSetToRangeSet(rowSet);
     } else {
-      RowSet.Builder rowSetBuilder = RowSet.newBuilder();
-      ByteString startRow = ByteString.copyFrom(scan.getStartRow());
-      if (scan.isGetScan()) {
-        rowSetBuilder.addRowKeys(startRow);
-      } else {
-        RowRange.Builder range =  RowRange.newBuilder();
-        if (!startRow.isEmpty()) {
-          if (!OPEN_CLOSED_AVAILABLE || scan.includeStartRow()) {
-            // the default for start is closed
-            range.setStartKeyClosed(startRow);
-          } else {
-            range.setStartKeyOpen(startRow);
-          }
-        }
+      RangeSet<RowKeyWrapper> rangeSet = TreeRangeSet.create();
+      final ByteString startRow = ByteString.copyFrom(scan.getStartRow());
+      final ByteString stopRow = ByteString.copyFrom(scan.getStopRow());
 
-        ByteString stopRow = ByteString.copyFrom(scan.getStopRow());
-        if (!stopRow.isEmpty()) {
-          if (!OPEN_CLOSED_AVAILABLE || !scan.includeStopRow()) {
-            // the default for stop is open
-            range.setEndKeyOpen(stopRow);
-          } else {
-            range.setEndKeyClosed(stopRow);
-          }
-        }
-        rowSetBuilder.addRowRanges(range);
+      if (scan.isGetScan()) {
+        rangeSet.add(Range.singleton(new RowKeyWrapper(startRow)));
+      } else {
+        final BoundType startBound =
+            (!OPEN_CLOSED_AVAILABLE || scan.includeStartRow()) ? BoundType.CLOSED : BoundType.OPEN;
+        final BoundType endBound =
+            (!OPEN_CLOSED_AVAILABLE || !scan.includeStopRow()) ? BoundType.OPEN : BoundType.CLOSED;
+
+        rangeSet.add(rowRangeAdapter.boundedRange(startBound, startRow, endBound, stopRow));
       }
-      return rowSetBuilder.build();
+      return rangeSet;
     }
   }
 
-  private static ByteString quoteRegex(byte[] unquoted)  {
+  private static ByteString quoteRegex(byte[] unquoted) {
     try {
       return ReaderExpressionHelper.quoteRegularExpression(unquoted);
     } catch (IOException e) {
@@ -204,25 +191,22 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
       return Optional.absent();
     }
     try {
-      return filterAdapter
-          .adaptFilter(new FilterAdapterContext(scan, hooks), scan.getFilter());
+      return filterAdapter.adaptFilter(new FilterAdapterContext(scan, hooks), scan.getFilter());
     } catch (IOException ioe) {
       throw new RuntimeException("Failed to adapt filter", ioe);
     }
   }
 
-  private RowSet narrowRowSet(RowSet rowSet, Filter filter) {
+  private RangeSet<RowKeyWrapper> narrowRange(RangeSet<RowKeyWrapper> rangeSet, Filter filter) {
     if (filter == null) {
-      return rowSet;
+      return rangeSet;
     }
     RangeSet<RowKeyWrapper> filterRangeSet = filterAdapter.getIndexScanHint(filter);
     if (filterRangeSet.encloses(Range.<RowKeyWrapper>all())) {
-      return rowSet;
+      return rangeSet;
     }
-    RangeSet<RowKeyWrapper> scanRangeSet = rowRangeAdapter.rowSetToRangeSet(rowSet);
-    // intersection of scan ranges & filter ranges
-    scanRangeSet.removeAll(filterRangeSet.complement());
-    return rowRangeAdapter.rangeSetToRowSet(scanRangeSet);
+    rangeSet.removeAll(filterRangeSet.complement());
+    return rangeSet;
   }
 
   private Filters.Filter createColumnQualifierFilter(byte[] unquotedQualifier) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -134,6 +134,7 @@ public class TestBatchExecutor {
   private HBaseRequestAdapter requestAdapter;
 
   private BigtableOptions options;
+
   @Before
   public void setup() throws InterruptedException {
     options = BigtableOptions.builder()

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowRangeAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowRangeAdapter.java
@@ -39,11 +39,15 @@ public class TestRowRangeAdapter {
   private final RequestContext requestContext = RequestContext.create(
           InstanceName.of("ProjectId", "InstanceId"),
           "AppProfile");
+
   private RowRangeAdapter adapter;
+
+  private Query query;
 
   @Before
   public void setup() {
     this.adapter = new RowRangeAdapter();
+    this.query = Query.create("tableId");
   }
 
   @Test
@@ -52,7 +56,6 @@ public class TestRowRangeAdapter {
     RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
 
     assertEquals(ImmutableRangeSet.builder().build(), out);
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -70,8 +73,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -95,8 +96,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -120,8 +119,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -145,8 +142,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -170,8 +165,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -189,8 +182,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -204,7 +195,6 @@ public class TestRowRangeAdapter {
                 .setEndKeyOpen(ByteString.EMPTY)
         )
         .build();
-
     RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
 
     RangeSet<RowKeyWrapper> expected = ImmutableRangeSet.<RowKeyWrapper>builder()
@@ -233,8 +223,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -257,8 +245,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -281,8 +267,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -305,8 +289,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }
@@ -347,8 +329,6 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-
-    Query query = Query.create(TABLE_ID);
     adapter.rangeSetToByteStringRange(out, query);
     assertEquals(in, query.toProto(requestContext).getRows());
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowRangeAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowRangeAdapter.java
@@ -19,6 +19,9 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.bigtable.v2.RowRange;
 import com.google.bigtable.v2.RowSet;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.InstanceName;
+import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.util.RowKeyWrapper;
 import com.google.common.collect.ImmutableRangeSet;
 import com.google.common.collect.Range;
@@ -32,6 +35,10 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TestRowRangeAdapter {
 
+  private final String TABLE_ID = "tableId";
+  private final RequestContext requestContext = RequestContext.create(
+          InstanceName.of("ProjectId", "InstanceId"),
+          "AppProfile");
   private RowRangeAdapter adapter;
 
   @Before
@@ -45,7 +52,9 @@ public class TestRowRangeAdapter {
     RangeSet<RowKeyWrapper> out = adapter.rowSetToRangeSet(in);
 
     assertEquals(ImmutableRangeSet.builder().build(), out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -61,7 +70,10 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -83,7 +95,10 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -105,7 +120,10 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -127,7 +145,10 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -149,7 +170,10 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -165,7 +189,10 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -206,7 +233,10 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -227,7 +257,10 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -248,7 +281,10 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -269,7 +305,10 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 
   @Test
@@ -308,6 +347,9 @@ public class TestRowRangeAdapter {
         .build();
 
     assertEquals(expected, out);
-    assertEquals(in, adapter.rangeSetToRowSet(out));
+
+    Query query = Query.create(TABLE_ID);
+    adapter.rangeSetToByteStringRange(out, query);
+    assertEquals(in, query.toProto(requestContext).getRows());
   }
 }

--- a/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
+++ b/bigtable-dataflow-parent/bigtable-beam-import/src/main/java/com/google/cloud/bigtable/beam/TemplateUtils.java
@@ -15,10 +15,10 @@
  */
 package com.google.cloud.bigtable.beam;
 
-import static com.google.cloud.bigtable.beam.CloudBigtableScanConfiguration.MARKER_APP_PROFILE_ID;
-import static com.google.cloud.bigtable.beam.CloudBigtableScanConfiguration.MARKER_INSTANCE_ID;
-import static com.google.cloud.bigtable.beam.CloudBigtableScanConfiguration.MARKER_PROJECT_ID;
-import static com.google.cloud.bigtable.beam.CloudBigtableScanConfiguration.MARKER_ID;
+import static com.google.cloud.bigtable.beam.CloudBigtableScanConfiguration.PLACEHOLDER_APP_PROFILE_ID;
+import static com.google.cloud.bigtable.beam.CloudBigtableScanConfiguration.PLACEHOLDER_INSTANCE_ID;
+import static com.google.cloud.bigtable.beam.CloudBigtableScanConfiguration.PLACEHOLDER_PROJECT_ID;
+import static com.google.cloud.bigtable.beam.CloudBigtableScanConfiguration.PLACEHOLDER_TABLE_ID;
 
 import com.google.bigtable.repackaged.com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.internal.RequestContext;
@@ -103,15 +103,14 @@ public class TemplateUtils {
         }
 
         ReadHooks readHooks = new DefaultReadHooks();
-        Query query = Query.create(MARKER_ID);
+        Query query = Query.create(PLACEHOLDER_TABLE_ID);
         RequestContext requestContext = RequestContext
-            .create(InstanceName.of(MARKER_PROJECT_ID, MARKER_INSTANCE_ID), MARKER_APP_PROFILE_ID);
+            .create(InstanceName.of(PLACEHOLDER_PROJECT_ID, PLACEHOLDER_INSTANCE_ID),
+                PLACEHOLDER_APP_PROFILE_ID);
         Adapters.SCAN_ADAPTER.adapt(scan, readHooks, query);
         readHooks.applyPreSendHook(query);
-        cachedRequest = ReadRowsRequest.newBuilder(query.toProto(requestContext))
-                .setTableName(MARKER_ID)
-                .setAppProfileId(MARKER_ID)
-                .build();
+
+        cachedRequest = query.toProto(requestContext);
       }
       return cachedRequest;
     }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
@@ -15,6 +15,10 @@
  */
 package com.google.cloud.bigtable.beam;
 
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.InstanceName;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
@@ -276,11 +280,21 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
         if (scan == null) {
           scan = new Scan();
         }
-        ReadRowsRequest.Builder builder = Adapters.SCAN_ADAPTER.adapt(scan, readHooks);
-        request =  StaticValueProvider.of(readHooks.applyPreSendHook(builder.build()));
+        Query query = Query.create(tableId.get());
+        Adapters.SCAN_ADAPTER.adapt(scan, readHooks, query);
+        ValueProvider<String> appProfileIdValue =
+            additionalConfiguration.get(BigtableOptionsFactory.APP_PROFILE_ID_KEY);
+        String appProfileId = "";
+        if (appProfileIdValue != null) {
+          appProfileId = appProfileIdValue.get();
+        }
+        RequestContext requestContext = RequestContext
+            .create(InstanceName.of(projectId.get(), instanceId.get()), appProfileId);
+        readHooks.applyPreSendHook(query);
+        request = StaticValueProvider.of(query.toProto(requestContext));
       }
-      return new CloudBigtableScanConfiguration(projectId, instanceId, tableId,
-          request, additionalConfiguration);
+      return new CloudBigtableScanConfiguration(projectId, instanceId, tableId, request,
+          additionalConfiguration);
     }
   }
 

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfigurationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfigurationTest.java
@@ -15,6 +15,10 @@
  */
 package com.google.cloud.bigtable.beam;
 
+import com.google.bigtable.repackaged.com.google.bigtable.v2.RowRange;
+import com.google.bigtable.repackaged.com.google.bigtable.v2.RowSet;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.grpc.BigtableInstanceName;
+import com.google.bigtable.repackaged.com.google.protobuf.ByteString;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.hadoop.hbase.client.Scan;
@@ -137,5 +141,36 @@ public class CloudBigtableScanConfigurationTest {
             .withRequest(StaticValueProvider.of(updatedRequest))
             .build();
     Assert.assertEquals(withRegularParameters, withRuntimeParameters);
+  }
+
+  @Test
+  public void testReadRowsRequest(){
+    CloudBigtableScanConfiguration withConfiguration =
+        new CloudBigtableScanConfiguration.Builder()
+            .withKeys(START_ROW, STOP_ROW)
+            .withProjectId(PROJECT)
+            .withInstanceId(INSTANCE)
+            .withAppProfileId("app-profile")
+            .withTableId(TABLE)
+            .build();
+
+    BigtableInstanceName instanceName = new BigtableInstanceName(PROJECT, INSTANCE);
+    ReadRowsRequest request =
+        ReadRowsRequest.newBuilder()
+            .setTableName(instanceName.toTableNameStr(TABLE))
+            .setAppProfileId("app-profile")
+            .setRows(RowSet.newBuilder()
+                .addRowRanges(
+                    RowRange.newBuilder()
+                        .setStartKeyClosed(ByteString.copyFrom(START_ROW))
+                        .setEndKeyOpen(ByteString.copyFrom(STOP_ROW))))
+            .build();
+    CloudBigtableScanConfiguration withRequest = new CloudBigtableScanConfiguration.Builder()
+        .withRequest(request)
+        .withProjectId(PROJECT)
+        .withInstanceId(INSTANCE)
+        .withTableId(TABLE)
+        .build();
+    Assert.assertEquals(withRequest.getRequest(), withConfiguration.getRequest());
   }
 }

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
@@ -15,6 +15,9 @@
  */
 package com.google.cloud.bigtable.dataflow;
 
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.InstanceName;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.Query;
 import java.util.Map;
 import java.util.Objects;
 
@@ -177,8 +180,12 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
         if (scan == null) {
           scan = new Scan();
         }
-        ReadRowsRequest.Builder builder = Adapters.SCAN_ADAPTER.adapt(scan, readHooks);
-        request = readHooks.applyPreSendHook(builder.build());
+        Query query = Query.create(tableId);
+        Adapters.SCAN_ADAPTER.adapt(scan, readHooks, query);
+        RequestContext requestContext =
+            RequestContext.create(InstanceName.of(projectId, instanceId), "");
+        readHooks.applyPreSendHook(query);
+        request = query.toProto(requestContext);
       }
       return new CloudBigtableScanConfiguration(projectId, instanceId, tableId,
           request, additionalConfiguration);

--- a/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-dataflow/src/main/java/com/google/cloud/bigtable/dataflow/CloudBigtableScanConfiguration.java
@@ -15,15 +15,17 @@
  */
 package com.google.cloud.bigtable.dataflow;
 
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.APP_PROFILE_ID_KEY;
+
 import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.InstanceName;
 import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.Query;
+
 import java.util.Map;
 import java.util.Objects;
 
 import com.google.cloud.bigtable.hbase.util.ByteStringer;
 import org.apache.hadoop.hbase.client.Scan;
-
 import com.google.bigtable.repackaged.com.google.bigtable.v2.ReadRowsRequest;
 import com.google.bigtable.repackaged.com.google.bigtable.v2.RowRange;
 import com.google.bigtable.repackaged.com.google.bigtable.v2.RowSet;
@@ -182,8 +184,13 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
         }
         Query query = Query.create(tableId);
         Adapters.SCAN_ADAPTER.adapt(scan, readHooks, query);
+
+        String appProfileId = "";
+        if (additionalConfiguration.containsKey(APP_PROFILE_ID_KEY)) {
+          appProfileId = additionalConfiguration.get(APP_PROFILE_ID_KEY);
+        }
         RequestContext requestContext =
-            RequestContext.create(InstanceName.of(projectId, instanceId), "");
+            RequestContext.create(InstanceName.of(projectId, instanceId), appProfileId);
         readHooks.applyPreSendHook(query);
         request = query.toProto(requestContext);
       }


### PR DESCRIPTION
Fix for calling ScanAdapter#adapt()
 - Used MARKER_ID which is an empty string for changing back and forth between ReadRowsRequest to Query.
 - Also added an appProfileId check




