### PR TITLE
Implementing BigtableTableAdminClietwrapper

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -26,7 +26,7 @@ import com.google.cloud.bigtable.config.BulkOptions;
 import com.google.cloud.bigtable.config.CredentialOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.config.RetryOptions;
-import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
 import com.google.cloud.bigtable.grpc.async.AsyncExecutor;
 import com.google.cloud.bigtable.grpc.async.BulkMutation;
 import com.google.cloud.bigtable.grpc.async.BulkRead;
@@ -160,6 +160,7 @@ public class BigtableSession implements Closeable {
   private final BigtableDataClient throttlingDataClient;
 
   private BigtableTableAdminClient tableAdminClient;
+  private IBigtableTableAdminClient adminClientWrapper;
   private BigtableInstanceGrpcClient instanceAdminClient;
 
   private final BigtableOptions options;
@@ -375,6 +376,19 @@ public class BigtableSession implements Closeable {
           BigtableSessionSharedThreadPools.getInstance().getRetryExecutor(), options);
     }
     return tableAdminClient;
+  }
+
+  /**
+   * <p>Getter for the field <code>adminClientWrapper</code>.</p>
+   *
+   * @return a {@link BigtableTableAdminClientWrapper} object.
+   * @throws java.io.IOException if any.
+   */
+  public synchronized IBigtableTableAdminClient getTableAdminClientWrapper() throws IOException {
+    if (adminClientWrapper == null) {
+      adminClientWrapper = new BigtableTableAdminClientWrapper(getTableAdminClient(), options);
+    }
+    return adminClientWrapper;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClientWrapper.java
@@ -27,6 +27,7 @@ import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -196,23 +197,34 @@ public class BigtableTableAdminClientWrapper implements IBigtableTableAdminClien
   /** {@inheritDoc} */
   @Override
   public void dropRowRange(String tableId, String rowKeyPrefix) {
-    DropRowRangeRequest requestProto = DropRowRangeRequest.newBuilder()
+    DropRowRangeRequest.Builder dropRequestProtoBuiler = DropRowRangeRequest.newBuilder()
         .setName(instanceName.toTableNameStr(tableId))
-        .setRowKeyPrefix(ByteString.copyFromUtf8(rowKeyPrefix))
-        .build();
+        .setDeleteAllDataFromTable(true);
 
-    adminClient.dropRowRange(requestProto);
+    if(!Strings.isNullOrEmpty(rowKeyPrefix)){
+      dropRequestProtoBuiler
+          .setDeleteAllDataFromTable(false)
+          .setRowKeyPrefix(ByteString.copyFromUtf8(rowKeyPrefix));
+    }
+
+    adminClient.dropRowRange(dropRequestProtoBuiler.build());
   }
 
   /** {@inheritDoc} */
   @Override
   public ListenableFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix) {
-    DropRowRangeRequest requestProto = DropRowRangeRequest.newBuilder()
+    DropRowRangeRequest.Builder dropRequestProtoBuiler = DropRowRangeRequest.newBuilder()
         .setName(instanceName.toTableNameStr(tableId))
-        .setRowKeyPrefix(ByteString.copyFromUtf8(rowKeyPrefix))
-        .build();
+        .setDeleteAllDataFromTable(true);
 
-    return Futures.transform(adminClient.dropRowRangeAsync(requestProto), new Function<Empty, Void>() {
+    if(!Strings.isNullOrEmpty(rowKeyPrefix)){
+      dropRequestProtoBuiler
+          .setDeleteAllDataFromTable(false)
+          .setRowKeyPrefix(ByteString.copyFromUtf8(rowKeyPrefix));
+    }
+
+    return Futures.transform(adminClient.dropRowRangeAsync(dropRequestProtoBuiler.build()),
+        new Function<Empty, Void>() {
       @Override
       public Void apply(Empty empty) {
           return null;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminClientWrapper.java
@@ -197,17 +197,17 @@ public class BigtableTableAdminClientWrapper implements IBigtableTableAdminClien
   /** {@inheritDoc} */
   @Override
   public void dropRowRange(String tableId, String rowKeyPrefix) {
-    DropRowRangeRequest.Builder dropRequestProtoBuiler = DropRowRangeRequest.newBuilder()
+    DropRowRangeRequest.Builder dropRequestProtoBuilder = DropRowRangeRequest.newBuilder()
         .setName(instanceName.toTableNameStr(tableId))
         .setDeleteAllDataFromTable(true);
 
     if(!Strings.isNullOrEmpty(rowKeyPrefix)){
-      dropRequestProtoBuiler
+      dropRequestProtoBuilder
           .setDeleteAllDataFromTable(false)
           .setRowKeyPrefix(ByteString.copyFromUtf8(rowKeyPrefix));
     }
 
-    adminClient.dropRowRange(dropRequestProtoBuiler.build());
+    adminClient.dropRowRange(dropRequestProtoBuilder.build());
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableTableAdminClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableTableAdminClientWrapper.java
@@ -216,9 +216,10 @@ public class TestBigtableTableAdminClientWrapper {
   }
 
   @Test
-  public void dropRowRange(){
+  public void dropRowRangeForDeleteByPrefix(){
     DropRowRangeRequest request = DropRowRangeRequest.newBuilder()
         .setName(TABLE_NAME)
+        .setDeleteAllDataFromTable(false)
         .setRowKeyPrefix(ByteString.copyFromUtf8(ROW_KEY_PREFIX))
         .build();
 
@@ -229,15 +230,43 @@ public class TestBigtableTableAdminClientWrapper {
   }
 
   @Test
-  public void dropRowRangeAsync(){
+  public void dropRowRangeForTruncate(){
     DropRowRangeRequest request = DropRowRangeRequest.newBuilder()
         .setName(TABLE_NAME)
+        .setDeleteAllDataFromTable(true)
+        .build();
+
+    doNothing().when(mockAdminClient).dropRowRange(request);
+    clientWrapper.dropRowRange(TABLE_ID, request.getRowKeyPrefix().toStringUtf8());
+
+    verify(mockAdminClient).dropRowRange(request);
+  }
+
+  @Test
+  public void dropRowRangeAsyncForDeleteByPrefix(){
+    DropRowRangeRequest request = DropRowRangeRequest.newBuilder()
+        .setName(TABLE_NAME)
+        .setDeleteAllDataFromTable(false)
         .setRowKeyPrefix(ByteString.copyFromUtf8(ROW_KEY_PREFIX))
         .build();
 
     when(mockAdminClient.dropRowRangeAsync(request))
         .thenReturn(immediateFuture(Empty.newBuilder().build()));
     clientWrapper.dropRowRangeAsync(TABLE_ID, ROW_KEY_PREFIX);
+
+    verify(mockAdminClient).dropRowRangeAsync(request);
+  }
+
+  @Test
+  public void dropRowRangeAsyncForTruncate(){
+    DropRowRangeRequest request = DropRowRangeRequest.newBuilder()
+        .setName(TABLE_NAME)
+        .setDeleteAllDataFromTable(true)
+        .build();
+
+    when(mockAdminClient.dropRowRangeAsync(request))
+        .thenReturn(immediateFuture(Empty.newBuilder().build()));
+    clientWrapper.dropRowRangeAsync(TABLE_ID, request.getRowKeyPrefix().toStringUtf8());
 
     verify(mockAdminClient).dropRowRangeAsync(request);
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableTableAdminClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableTableAdminClientWrapper.java
@@ -237,7 +237,7 @@ public class TestBigtableTableAdminClientWrapper {
         .build();
 
     doNothing().when(mockAdminClient).dropRowRange(request);
-    clientWrapper.dropRowRange(TABLE_ID, request.getRowKeyPrefix().toStringUtf8());
+    clientWrapper.dropRowRange(TABLE_ID, null);
 
     verify(mockAdminClient).dropRowRange(request);
   }
@@ -266,7 +266,7 @@ public class TestBigtableTableAdminClientWrapper {
 
     when(mockAdminClient.dropRowRangeAsync(request))
         .thenReturn(immediateFuture(Empty.newBuilder().build()));
-    clientWrapper.dropRowRangeAsync(TABLE_ID, request.getRowKeyPrefix().toStringUtf8());
+    clientWrapper.dropRowRangeAsync(TABLE_ID, null);
 
     verify(mockAdminClient).dropRowRangeAsync(request);
   }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
@@ -103,67 +103,24 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
     }
 
     /**
-     * Provides an updated request by replacing the row set and adding a row range with start and
-     * end keys in the existing request.
-     */
-    private static class RequestWithKeysValueProvider
-        implements ValueProvider<ReadRowsRequest>, Serializable {
-      private final ByteString start;
-      private final ByteString stop;
-      private final ValueProvider<ReadRowsRequest> request;
-      private ReadRowsRequest cachedRequest;
-
-      RequestWithKeysValueProvider(
-          ByteString start, ByteString stop, ValueProvider<ReadRowsRequest> request) {
-        this.start = start;
-        this.stop = stop;
-        this.request = request;
-      }
-
-      @Override
-      public ReadRowsRequest get() {
-        if (cachedRequest == null) {
-          cachedRequest =
-              request
-                  .get()
-                  .toBuilder()
-                  .setRows(
-                      RowSet.newBuilder()
-                          .addRowRanges(
-                              RowRange.newBuilder().setStartKeyClosed(start).setEndKeyOpen(stop)))
-                  .build();
-        }
-        return cachedRequest;
-      }
-
-      @Override
-      public boolean isAccessible() {
-        return request.isAccessible();
-      }
-
-      @Override
-      public String toString() {
-        if (isAccessible()) {
-          return String.valueOf(get());
-        }
-        return VALUE_UNAVAILABLE;
-      }
-    }
-
-    /**
      * Internal API that allows a Source to configure the request with a new start/stop row range.
      * @param startKey The first key, inclusive.
      * @param stopKey The last key, exclusive.
      * @return The {@link CloudBigtableScanConfiguration.Builder} for chaining convenience.
      */
     Builder withKeys(byte[] startKey, byte[] stopKey) {
+      Preconditions.checkNotNull(request, "Request cannot be empty.");
+      Preconditions.checkState(request.isAccessible(), "Request must be accessible.");
       final ByteString start = ByteStringer.wrap(startKey);
       final ByteString stop = ByteStringer.wrap(stopKey);
-      ValueProvider<ReadRowsRequest> request =
-          this.request == null
-              ? StaticValueProvider.of(ReadRowsRequest.getDefaultInstance())
-              : this.request;
-      return withRequest(new RequestWithKeysValueProvider(start, stop, request));
+      return withRequest(request
+          .get()
+          .toBuilder()
+          .setRows(
+              RowSet.newBuilder()
+                  .addRowRanges(
+                      RowRange.newBuilder().setStartKeyClosed(start).setEndKeyOpen(stop)))
+          .build());
     }
 
     /**

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
@@ -19,6 +19,8 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Objects;
 
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.bigtable.repackaged.com.google.common.base.Preconditions;
 import com.google.cloud.bigtable.hbase.util.ByteStringer;
 import org.apache.beam.sdk.io.range.ByteKey;
@@ -81,6 +83,11 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
       ReadRowsRequest.Builder builder = Adapters.SCAN_ADAPTER.adapt(scan, readHooks);
       withRequest(readHooks.applyPreSendHook(builder.build()));
       return this;
+    }
+
+    Builder withQuery(Query query) {
+      RequestContext dummyContext = RequestContext.create("Dummy Project", "Dummy Instance", "");
+      return this.withRequest(query.toProto(dummyContext).toBuilder().setTableName("").build());
     }
 
     /**

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfigurationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfigurationTest.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.beam;
 
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.Filters;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.data.v2.models.Query;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.hadoop.hbase.client.Scan;
@@ -66,6 +68,19 @@ public class CloudBigtableScanConfigurationTest {
 
     // Test that CloudBigtableScanConfigurations with different scans should not be equal.
     Assert.assertNotEquals(underTest1, underTest3);
+  }
+
+  @Test
+  public void testQuery() {
+    Filters.Filter filter = Filters.FILTERS.family().exactMatch("someFamily");
+    ReadRowsRequest request = config.toBuilder().withQuery(
+        Query
+            .create("SomeTable")
+            .filter(filter))
+        .build()
+        .getRequest();
+    Assert.assertEquals(request.getTableName(), config.getRequest().getTableName());
+    Assert.assertEquals(request.getFilter(), filter.toProto());
   }
 
   @Test

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase2_x;
 
 import com.google.cloud.bigtable.hbase.util.ModifyTableBuilder;
-import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -345,10 +344,10 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
    if (!preserveSplits) {
       LOG.info("truncate will preserveSplits. The passed in variable is ignored.");
    }
-   // rowKeyPrefix set to Empty ByteString to truncate data from specified table.
+   // rowKeyPrefix set to Empty String which truncates data from specified table.
    return FutureUtils.toCompletableFuture(
         tableAdminClientWrapper
-          .dropRowRangeAsync(tableName.getNameAsString(), ByteString.EMPTY.toStringUtf8()))
+          .dropRowRangeAsync(tableName.getNameAsString(), ""))
         .thenApply(r -> null);
   }
   /* ******* Unsupported methods *********** */

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@ limitations under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <!-- google-cloud-java related dependency versions -->
-        <google-cloud.version>0.76.0-alpha</google-cloud.version>
-        <opencensus.version>0.15.0</opencensus.version>
+        <google-cloud.version>0.78.0-alpha</google-cloud.version>
+        <opencensus.version>0.17.0</opencensus.version>
         <guava.version>26.0-android</guava.version>
 
         <!-- hbase dependency versions -->


### PR DESCRIPTION
## What changes it contains
Initial Implementation for `BigtableTableAdminClientwrapper` to adapt to v2.models classes.
This is related to the ongoing wrapping of native cloud BigTable adapters on top of Google-Cloud-java adapter.

-  `AbstractBigtableAdmin`  & `BigtableAdmin`  is now adapting to v2.models, (except i.e. **`getTable()`** & snapshot related operations ).
- Modified `BigtableAdminWrapper#dropRowRange` & `BigtableAdminWrapper#dropRowRangeAsync` to support for truncate and deleteByPrefix.
- `hbase2.xBigtableTableAdminClient` is uneffected by this PR as it contains snapshot related operation (this would be separate PR) .

***
**This PR is only for review**