### PR TITLE
Adding ModelRowAdapter for models.Row

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase.adapters;
 
+import com.google.cloud.bigtable.hbase.adapters.read.ModelRowAdapter;
 import com.google.cloud.bigtable.hbase.adapters.read.RowRangeAdapter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Append;
@@ -38,6 +39,8 @@ import com.google.cloud.bigtable.hbase.adapters.read.ScanAdapter;
 public final class Adapters {
   /** Constant <code>ROW_ADAPTER</code> */
   public static final RowAdapter ROW_ADAPTER = new RowAdapter();
+  /** Constant <code>MODEL_ROW_ADAPTER</code> */
+  public static final ModelRowAdapter MODEL_ROW_ADAPTER = new ModelRowAdapter();
   /** Constant <code>FLAT_ROW_ADAPTER</code> */
   public static final FlatRowAdapter FLAT_ROW_ADAPTER = new FlatRowAdapter();
   /** Constant <code>APPEND_ADAPTER</code> */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ModelRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ModelRowAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google LLC. All Rights Reserved.
+ * Copyright 2019 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ModelRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ModelRowAdapter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.read;
+
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.hbase.adapters.ResponseAdapter;
+import com.google.cloud.bigtable.hbase.util.ByteStringer;
+import com.google.cloud.bigtable.hbase.util.TimestampConverter;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.util.Bytes;
+
+/**
+ * Adapt between a {@link Row} and an hbase client {@link Result}.
+ */
+public class ModelRowAdapter implements ResponseAdapter<Row, Result> {
+
+  @Override
+  public Result adaptResponse(Row response) {
+    if (response == null) {
+      return new Result();
+    }
+
+    SortedSet<Cell> hbaseCells = new TreeSet<>(KeyValue.COMPARATOR);
+    byte[] rowKey = ByteStringer.extract(response.getKey());
+    for (com.google.cloud.bigtable.data.v2.models.RowCell rowCell : response.getCells()) {
+      // Cells with labels are for internal use, do not return them.
+      // TODO(kevinsi4508): Filter out targeted {@link WhileMatchFilter} labels.
+      if (rowCell.getLabels().size() > 0) {
+        continue;
+      }
+      byte[] familyNameBytes = Bytes.toBytes(rowCell.getFamily());
+      byte[] columnQualifier = ByteStringer.extract(rowCell.getQualifier());
+      long hbaseTimestamp = TimestampConverter.bigtable2hbase(rowCell.getTimestamp());
+      RowCell keyValue = new RowCell(
+          rowKey,
+          familyNameBytes,
+          columnQualifier,
+          hbaseTimestamp,
+          ByteStringer.extract(rowCell.getValue()));
+
+      hbaseCells.add(keyValue);
+    }
+
+    return Result.create(hbaseCells.toArray(new Cell[hbaseCells.size()]));
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ModelRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ModelRowAdapter.java
@@ -19,6 +19,7 @@ import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.hbase.adapters.ResponseAdapter;
 import com.google.cloud.bigtable.hbase.util.ByteStringer;
 import com.google.cloud.bigtable.hbase.util.TimestampConverter;
+import com.google.common.collect.ImmutableList;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import org.apache.hadoop.hbase.Cell;
@@ -37,7 +38,7 @@ public class ModelRowAdapter implements ResponseAdapter<Row, Result> {
       return new Result();
     }
 
-    SortedSet<Cell> hbaseCells = new TreeSet<>(KeyValue.COMPARATOR);
+    ImmutableList.Builder<Cell> hbaseCellBuilder = ImmutableList.builder();
     byte[] rowKey = ByteStringer.extract(response.getKey());
     for (com.google.cloud.bigtable.data.v2.models.RowCell rowCell : response.getCells()) {
       // Cells with labels are for internal use, do not return them.
@@ -55,9 +56,10 @@ public class ModelRowAdapter implements ResponseAdapter<Row, Result> {
           hbaseTimestamp,
           ByteStringer.extract(rowCell.getValue()));
 
-      hbaseCells.add(keyValue);
+      hbaseCellBuilder.add(keyValue);
     }
 
+    ImmutableList<Cell> hbaseCells = hbaseCellBuilder.build();
     return Result.create(hbaseCells.toArray(new Cell[hbaseCells.size()]));
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestModelRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestModelRowAdapter.java
@@ -77,9 +77,6 @@ public class TestModelRowAdapter {
     rowCells.add(RowCell.create(FAMILY_2, QUALIFIER_2, TIMESTAMP_MS_2, LABEL_LIST, VALUE_3));
     rowCells.add(RowCell.create(FAMILY_2, QUALIFIER_1, TIMESTAMP_MS_1, LABEL_LIST, VALUE_4));
 
-    //Added duplicate row, should be ignored
-    rowCells.add(RowCell.create(FAMILY_2, QUALIFIER_1, TIMESTAMP_MS_1, LABEL_LIST, VALUE_4));
-
     //Row containing Label, Should be ignored
     rowCells.add(RowCell.create(FAMILY_1, QUALIFIER_2, TIMESTAMP_MS_3,
         Collections.singletonList(LABEL), VALUE_1));
@@ -97,9 +94,9 @@ public class TestModelRowAdapter {
         new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, FAMILY_1.getBytes(),
             QUALIFIER_2.toByteArray(), TIMESTAMP_MILLS_2, VALUE_2.toByteArray()),
         new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, FAMILY_2.getBytes(),
-            QUALIFIER_1.toByteArray(), TIMESTAMP_MILLS_1, VALUE_3.toByteArray()),
+            QUALIFIER_2.toByteArray(), TIMESTAMP_MILLS_2, VALUE_3.toByteArray()),
         new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, FAMILY_2.getBytes(),
-            QUALIFIER_2.toByteArray(), TIMESTAMP_MILLS_2, VALUE_4.toByteArray()),
+            QUALIFIER_1.toByteArray(), TIMESTAMP_MILLS_1, VALUE_4.toByteArray()),
     };
     assertArrayEquals(expectedCells, result.rawCells());
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestModelRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestModelRowAdapter.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.read;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.data.v2.models.RowCell;
+import com.google.cloud.bigtable.hbase.util.ByteStringer;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import java.util.Collections;
+import java.util.List;
+import org.apache.hadoop.hbase.client.Result;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for the {@link ModelRowAdapter}.
+ */
+@RunWith(JUnit4.class)
+public class TestModelRowAdapter {
+
+  private static final String FAMILY_1 = "firstFamily";
+  private static final String FAMILY_2 = "secondFamily";
+  private static final ByteString QUALIFIER_1 = ByteString.copyFromUtf8("qualifier1");
+  private static final ByteString QUALIFIER_2 = ByteString.copyFromUtf8("qualifier2");
+  private static final long TIMESTAMP_MS_1 = 12345600;
+  private static final long TIMESTAMP_MS_2 = 65432100;
+  private static final long TIMESTAMP_MILLS_1 = TIMESTAMP_MS_1/1000;
+  private static final long TIMESTAMP_MILLS_2 = TIMESTAMP_MS_2/1000;
+  private static final String LABEL = "label";
+  private static final List<String> LABEL_LIST = Collections.emptyList();
+  private static final ByteString VALUE_1 = ByteString.copyFromUtf8("test-value-1");
+  private static final ByteString VALUE_2 = ByteString.copyFromUtf8("test-value-2");
+  private static final ByteString VALUE_3 = ByteString.copyFromUtf8("test-value-3");
+  private static final ByteString VALUE_4 = ByteString.copyFromUtf8("test-value-4");
+  private static final ByteString ROW_KEY = ByteString.copyFromUtf8("test-key");
+
+  private ModelRowAdapter adapter = new ModelRowAdapter();
+
+  @Test
+  public void testAdaptResponseWhenNull(){
+    Result result = adapter.adaptResponse(null);
+    assertNull(result.rawCells());
+  }
+
+  @Test
+  public void testAdaptResWithEmptyRow(){
+    Row row = Row.create(ROW_KEY, Collections.<RowCell>emptyList());
+    Result result = adapter.adaptResponse(row);
+    assertEquals(0, result.rawCells().length);
+  }
+
+  @Test
+  public void testAdaptResWithRow(){
+    ImmutableList.Builder<RowCell> rowCells = ImmutableList.builder();
+    rowCells.add(RowCell.create(FAMILY_1, QUALIFIER_1, TIMESTAMP_MS_1, LABEL_LIST, VALUE_1));
+    rowCells.add(RowCell.create(FAMILY_1, QUALIFIER_2, TIMESTAMP_MS_2, LABEL_LIST, VALUE_2));
+    rowCells.add(RowCell.create(FAMILY_2, QUALIFIER_2, TIMESTAMP_MS_2, LABEL_LIST, VALUE_3));
+    rowCells.add(RowCell.create(FAMILY_2, QUALIFIER_1, TIMESTAMP_MS_1, LABEL_LIST, VALUE_4));
+    //Added duplicate row
+    rowCells.add(RowCell.create(FAMILY_2, QUALIFIER_1, TIMESTAMP_MS_1, LABEL_LIST, VALUE_4));
+    //Added Row with label
+    rowCells.add(RowCell.create(FAMILY_1, QUALIFIER_2, TIMESTAMP_MILLS_1,
+        Collections.singletonList(LABEL), VALUE_1));
+    Row inputRow = Row.create(ROW_KEY, rowCells.build());
+    Result result = adapter.adaptResponse(inputRow);
+    assertEquals(4, result.rawCells().length);
+
+    // The duplicate row and label cells have been removed. The timestamp micros get converted to
+    // millisecond accuracy.
+    byte[] keyArray = ByteStringer.extract(ROW_KEY);
+    org.apache.hadoop.hbase.Cell[] expectedCells = new org.apache.hadoop.hbase.Cell[] {
+        new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, FAMILY_1.getBytes(),
+            QUALIFIER_1.toByteArray(), TIMESTAMP_MILLS_1, VALUE_1.toByteArray()),
+        new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, FAMILY_1.getBytes(),
+            QUALIFIER_2.toByteArray(), TIMESTAMP_MILLS_2, VALUE_2.toByteArray()),
+        new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, FAMILY_2.getBytes(),
+            QUALIFIER_1.toByteArray(), TIMESTAMP_MILLS_1, VALUE_3.toByteArray()),
+        new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, FAMILY_2.getBytes(),
+            QUALIFIER_2.toByteArray(), TIMESTAMP_MILLS_2, VALUE_4.toByteArray()),
+    };
+    assertArrayEquals(expectedCells, result.rawCells());
+  }
+}


### PR DESCRIPTION
## What Change this PR contains
Adding ModelRowAdapter: To convert `models.Row` to `hbase.client.Result`


Creating new ModelRowAdapter to be used until all reference of existing RowAdapter is removed.
Once that is achieved then either we can either apply same changes or rename this Adapter to RowAdapter.

