### PR TITLE
Preparing ColumnDescriptorAdapter & TableAdapter 

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/ColumnDescriptorAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/ColumnDescriptorAdapter.java
@@ -317,16 +317,19 @@ public class ColumnDescriptorAdapter {
   }
 
   /**
-   * Convert a Bigtable {@link com.google.bigtable.admin.v2.ColumnFamily} to an HBase {@link org.apache.hadoop.hbase.HColumnDescriptor}.
+   * Convert a Bigtable {@link com.google.cloud.bigtable.admin.v2.models.ColumnFamily} to an
+   * HBase {@link HColumnDescriptor}.
    * See {@link #convertGarbageCollectionRule(GcRule, HColumnDescriptor)} for more info.
    *
-   * @param familyName a {@link java.lang.String} object.
-   * @param columnFamily a {@link com.google.bigtable.admin.v2.ColumnFamily} object.
+   * @param columnFamily a {@link com.google.cloud.bigtable.admin.v2.models.ColumnFamily} object.
    * @return a {@link org.apache.hadoop.hbase.HColumnDescriptor} object.
    */
-  public HColumnDescriptor adapt(String familyName, ColumnFamily columnFamily) {
-    HColumnDescriptor hColumnDescriptor = new HColumnDescriptor(familyName);
-    convertGarbageCollectionRule(columnFamily.getGcRule(), hColumnDescriptor);
+  public HColumnDescriptor adapt(com.google.cloud.bigtable.admin.v2.models.ColumnFamily columnFamily) {
+    HColumnDescriptor hColumnDescriptor = new HColumnDescriptor(columnFamily.getId());
+    GCRule gcRule = columnFamily.getGCRule();
+    if(gcRule != null){
+      convertGarbageCollectionRule(gcRule.toProto(), hColumnDescriptor);
+    }
     return hColumnDescriptor;
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/admin/TableAdapter.java
@@ -18,9 +18,9 @@ package com.google.cloud.bigtable.hbase.adapters.admin;
 import static com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter.buildGarbageCollectionRule;
 
 import com.google.api.core.InternalApi;
-import com.google.bigtable.admin.v2.ColumnFamily;
+import com.google.cloud.bigtable.admin.v2.models.ColumnFamily;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
-import com.google.bigtable.admin.v2.Table;
+import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 
 import com.google.common.base.Preconditions;
@@ -92,10 +92,9 @@ public class TableAdapter {
    * @return a {@link HTableDescriptor} object.
    */
   public HTableDescriptor adapt(Table table) {
-    String tableId = bigtableInstanceName.toTableId(table.getName());
-    HTableDescriptor tableDescriptor = new HTableDescriptor(TableName.valueOf(tableId));
-    for (Entry<String, ColumnFamily> entry : table.getColumnFamiliesMap().entrySet()) {
-      tableDescriptor.addFamily(columnDescriptorAdapter.adapt(entry.getKey(), entry.getValue()));
+    HTableDescriptor tableDescriptor = new HTableDescriptor(TableName.valueOf(table.getId()));
+    for(ColumnFamily columnFamily : table.getColumnFamilies()){
+      tableDescriptor.addFamily(columnDescriptorAdapter.adapt(columnFamily));
     }
     return tableDescriptor;
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -267,6 +267,25 @@ public abstract class AbstractBigtableAdmin implements Admin {
     }
   }
 
+  // Used by the Hbase shell but not defined by Admin. Will be removed once the
+  // shell is switch to use the methods defined in the interface.
+  /**
+   * <p>getTableNames.</p>
+   *
+   * @param regex a {@link String} object.
+   * @return an array of {@link String} objects.
+   * @throws IOException if any.
+   */
+  @Deprecated
+  public String[] getTableNames(String regex) throws IOException {
+    TableName[] tableNames = listTableNames(regex);
+    String[] tableIds = new String[tableNames.length];
+    for (int i = 0; i < tableNames.length; i++) {
+      tableIds[i] = tableNames[i].getNameAsString();
+    }
+    return tableIds;
+  }
+
   /** {@inheritDoc} */
   @Override
   public void createTable(HTableDescriptor desc) throws IOException {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -262,7 +262,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
     GetTableRequest request = GetTableRequest.newBuilder().setName(bigtableTableName).build();
 
     try {
-      return tableAdapter.adapt(bigtableTableAdminClient.getTable(request));
+      return tableAdapter.adapt(Table.fromProto(bigtableTableAdminClient.getTable(request)));
     } catch (Throwable throwable) {
       if (Status.fromThrowable(throwable).getCode() == Status.Code.NOT_FOUND) {
         throw new TableNotFoundException(tableName);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -19,7 +19,6 @@ import static com.google.cloud.bigtable.hbase.util.ModifyTableBuilder.buildModif
 
 import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
-import com.google.bigtable.admin.v2.GetTableRequest;
 import com.google.bigtable.admin.v2.SnapshotTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
@@ -258,36 +257,14 @@ public abstract class AbstractBigtableAdmin implements Admin {
       return null;
     }
 
-    String bigtableTableName = toBigtableName(tableName);
-    GetTableRequest request = GetTableRequest.newBuilder().setName(bigtableTableName).build();
-
     try {
-      return tableAdapter.adapt(Table.fromProto(bigtableTableAdminClient.getTable(request)));
+      return tableAdapter.adapt(tableAdminClientWrapper.getTable(tableName.getNameAsString()));
     } catch (Throwable throwable) {
       if (Status.fromThrowable(throwable).getCode() == Status.Code.NOT_FOUND) {
         throw new TableNotFoundException(tableName);
       }
       throw new IOException("Failed to getTableDescriptor() on " + tableName, throwable);
     }
-  }
-
-  // Used by the Hbase shell but not defined by Admin. Will be removed once the
-  // shell is switch to use the methods defined in the interface.
-  /**
-   * <p>getTableNames.</p>
-   *
-   * @param regex a {@link java.lang.String} object.
-   * @return an array of {@link java.lang.String} objects.
-   * @throws java.io.IOException if any.
-   */
-  @Deprecated
-  public String[] getTableNames(String regex) throws IOException {
-    HTableDescriptor[] tableDescriptors = listTables(regex);
-    String[] tableNames = new String[tableDescriptors.length];
-    for (int i = 0; i < tableDescriptors.length; i++) {
-      tableNames[i] = tableDescriptors[i].getNameAsString();
-    }
-    return tableNames;
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestColumnDescriptorAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestColumnDescriptorAdapter.java
@@ -115,7 +115,7 @@ public class TestColumnDescriptorAdapter {
     descriptor.setTimeToLive(ttl);
     ColumnFamily result = adapter.adapt(descriptor);
     GCRules.GCRule expected = GCRULES.union().rule(GCRULES.maxAge(Duration.ofSeconds(ttl)))
-        .rule(GCRULES.maxVersions(1));
+            .rule(GCRULES.maxVersions(1));
     Assert.assertEquals(expected.toProto(), result.getGcRule());
   }
 
@@ -123,7 +123,7 @@ public class TestColumnDescriptorAdapter {
   public void ttlIsPreservedInColumnFamily() {
     // TTL of 1 day (in microseconds):
     GCRules.GCRule expected = GCRULES.union().rule(GCRULES.maxAge(Duration.ofSeconds(86400)))
-        .rule(GCRULES.maxVersions(1));
+            .rule(GCRULES.maxVersions(1));
     HColumnDescriptor descriptor = adapter.adapt(columnFamily(expected));
     Assert.assertEquals(1, descriptor.getMaxVersions());
     Assert.assertEquals(86400, descriptor.getTimeToLive());
@@ -203,6 +203,7 @@ public class TestColumnDescriptorAdapter {
     Assert.assertEquals(ttl, actual.getTimeToLive());
   }
 
+  //TODO: Remove this method and create ColumnFamily along with GCRule instead of using proto.
   private static com.google.cloud.bigtable.admin.v2.models.ColumnFamily columnFamily(GCRule rule) {
     return com.google.cloud.bigtable.admin.v2.models.ColumnFamily.fromProto("family",
         ColumnFamily.newBuilder().setGcRule(rule.toProto()).build());
@@ -210,13 +211,7 @@ public class TestColumnDescriptorAdapter {
 
   private GCRule minMaxRule(int minVersions, int ttl, int maxVersions) {
     GCRule intersection = GCRULES.intersection().rule(GCRULES.maxAge(Duration.ofSeconds(ttl)))
-        .rule(GCRULES.maxVersions(minVersions));
+            .rule(GCRULES.maxVersions(minVersions));
     return GCRULES.union().rule(intersection).rule(GCRULES.maxVersions(maxVersions));
-  }
-
-  private GCRule minMaxIntersectionRule(int minVersions, int ttl, int maxVersions) {
-    GCRule intersection = GCRULES.intersection().rule(GCRULES.maxAge(Duration.ofSeconds(ttl)))
-        .rule(GCRULES.maxVersions(minVersions));
-    return intersection;
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestColumnDescriptorAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestColumnDescriptorAdapter.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -115,7 +115,7 @@ public class TestColumnDescriptorAdapter {
     descriptor.setTimeToLive(ttl);
     ColumnFamily result = adapter.adapt(descriptor);
     GCRules.GCRule expected = GCRULES.union().rule(GCRULES.maxAge(Duration.ofSeconds(ttl)))
-            .rule(GCRULES.maxVersions(1));
+        .rule(GCRULES.maxVersions(1));
     Assert.assertEquals(expected.toProto(), result.getGcRule());
   }
 
@@ -123,9 +123,8 @@ public class TestColumnDescriptorAdapter {
   public void ttlIsPreservedInColumnFamily() {
     // TTL of 1 day (in microseconds):
     GCRules.GCRule expected = GCRULES.union().rule(GCRULES.maxAge(Duration.ofSeconds(86400)))
-            .rule(GCRULES.maxVersions(1));
-    HColumnDescriptor descriptor =
-        adapter.adapt("family", columnFamily(expected));
+        .rule(GCRULES.maxVersions(1));
+    HColumnDescriptor descriptor = adapter.adapt(columnFamily(expected));
     Assert.assertEquals(1, descriptor.getMaxVersions());
     Assert.assertEquals(86400, descriptor.getTimeToLive());
   }
@@ -141,7 +140,7 @@ public class TestColumnDescriptorAdapter {
   @Test
   public void maxVersionsIsPreservedInColumnFamily() {
     GCRules.GCRule expected = GCRULES.maxVersions(10);
-    HColumnDescriptor descriptor = adapter.adapt("family", columnFamily(expected));
+    HColumnDescriptor descriptor = adapter.adapt(columnFamily(expected));
     Assert.assertEquals(10, descriptor.getMaxVersions());
   }
 
@@ -156,8 +155,7 @@ public class TestColumnDescriptorAdapter {
 
   @Test
   public void minMaxTtlInColumnFamily() {
-    HColumnDescriptor descriptor = adapter.adapt("family",
-            columnFamily(minMaxRule(10, 86400, 20)));
+    HColumnDescriptor descriptor = adapter.adapt(columnFamily(minMaxRule(10, 86400, 20)));
     Assert.assertEquals(20, descriptor.getMaxVersions());
     Assert.assertEquals(10, descriptor.getMinVersions());
     Assert.assertEquals(86400, descriptor.getTimeToLive());
@@ -174,12 +172,15 @@ public class TestColumnDescriptorAdapter {
   @Test
   public void minVersionsMustBeLessThanMaxversionInExpression() {
     expectedException.expect(IllegalArgumentException.class);
-    adapter.adapt("family", columnFamily(minMaxRule(20, 86400, 10)));
+    adapter.adapt(columnFamily(minMaxRule(20, 86400, 10)));
   }
 
   @Test
   public void testBlankExpression(){
-    HColumnDescriptor descriptor = adapter.adapt("family", ColumnFamily.getDefaultInstance());
+    com.google.cloud.bigtable.admin.v2.models.ColumnFamily columnFamily =
+        com.google.cloud.bigtable.admin.v2.models.ColumnFamily.fromProto("family",
+            ColumnFamily.getDefaultInstance());
+    HColumnDescriptor descriptor = adapter.adapt(columnFamily);
     Assert.assertEquals(Integer.MAX_VALUE, descriptor.getMaxVersions());
     Assert.assertEquals(null, ColumnDescriptorAdapter.buildGarbageCollectionRule(descriptor));
   }
@@ -198,24 +199,24 @@ public class TestColumnDescriptorAdapter {
   public void testAdaptWithColumnFamilyForMaxAge(){
     int ttl = 86400;
     GCRule maxAgeGCRule = GCRULES.maxAge(Duration.ofSeconds(ttl));
-    ColumnFamily columnFamily = ColumnFamily.newBuilder().setGcRule(maxAgeGCRule.toProto()).build();
-    HColumnDescriptor actual = adapter.adapt(FAMILY_NAME, columnFamily);
+    HColumnDescriptor actual = adapter.adapt(columnFamily(maxAgeGCRule));
     Assert.assertEquals(ttl, actual.getTimeToLive());
   }
 
-  private static ColumnFamily columnFamily(GCRule rule) {
-    return ColumnFamily.newBuilder().setGcRule(rule.toProto()).build();
+  private static com.google.cloud.bigtable.admin.v2.models.ColumnFamily columnFamily(GCRule rule) {
+    return com.google.cloud.bigtable.admin.v2.models.ColumnFamily.fromProto("family",
+        ColumnFamily.newBuilder().setGcRule(rule.toProto()).build());
   }
 
   private GCRule minMaxRule(int minVersions, int ttl, int maxVersions) {
     GCRule intersection = GCRULES.intersection().rule(GCRULES.maxAge(Duration.ofSeconds(ttl)))
-            .rule(GCRULES.maxVersions(minVersions));
+        .rule(GCRULES.maxVersions(minVersions));
     return GCRULES.union().rule(intersection).rule(GCRULES.maxVersions(maxVersions));
   }
 
   private GCRule minMaxIntersectionRule(int minVersions, int ttl, int maxVersions) {
     GCRule intersection = GCRULES.intersection().rule(GCRULES.maxAge(Duration.ofSeconds(ttl)))
-            .rule(GCRULES.maxVersions(minVersions));
+        .rule(GCRULES.maxVersions(minVersions));
     return intersection;
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestTableAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestTableAdapter.java
@@ -17,9 +17,9 @@ package com.google.cloud.bigtable.hbase.adapters.admin;
 
 import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
 import com.google.bigtable.admin.v2.ColumnFamily;
-import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
+import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -102,9 +102,9 @@ public class TestTableAdapter {
     GCRule gcRule = GCRULES.maxVersions(1);
     ColumnFamily columnFamily = ColumnFamily.newBuilder()
             .setGcRule(gcRule.toProto()).build();
-    Table table = Table.newBuilder()
+    Table table = Table.fromProto(com.google.bigtable.admin.v2.Table.newBuilder()
             .setName(TABLE_NAME)
-            .putColumnFamilies(COLUMN_FAMILY, columnFamily).build();
+            .putColumnFamilies(COLUMN_FAMILY, columnFamily).build());
     HTableDescriptor actualTableDesc = tableAdapter.adapt(table);
 
     HTableDescriptor expected = new HTableDescriptor(TableName.valueOf(TABLE_ID));

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestTableAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/admin/TestTableAdapter.java
@@ -17,9 +17,9 @@ package com.google.cloud.bigtable.hbase.adapters.admin;
 
 import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
 import com.google.bigtable.admin.v2.ColumnFamily;
+import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.GCRules.GCRule;
-import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -102,10 +102,11 @@ public class TestTableAdapter {
     GCRule gcRule = GCRULES.maxVersions(1);
     ColumnFamily columnFamily = ColumnFamily.newBuilder()
             .setGcRule(gcRule.toProto()).build();
-    Table table = Table.fromProto(com.google.bigtable.admin.v2.Table.newBuilder()
+    Table table = Table.newBuilder()
             .setName(TABLE_NAME)
-            .putColumnFamilies(COLUMN_FAMILY, columnFamily).build());
-    HTableDescriptor actualTableDesc = tableAdapter.adapt(table);
+            .putColumnFamilies(COLUMN_FAMILY, columnFamily).build();
+    HTableDescriptor actualTableDesc = tableAdapter.adapt(
+        com.google.cloud.bigtable.admin.v2.models.Table.fromProto(table));
 
     HTableDescriptor expected = new HTableDescriptor(TableName.valueOf(TABLE_ID));
     expected.addFamily(new HColumnDescriptor(COLUMN_FAMILY));

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -232,7 +232,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
          r.stream()
             .filter(t -> !tableNamePattern.isPresent() ||
                 tableNamePattern.get().matcher(bigtableInstanceName.toTableId(t.getName())).matches())
-            .map(tableProto-> com.google.cloud.bigtable.admin.v2.models.Table.fromProto(tableProto))
+            .map(tableProto -> com.google.cloud.bigtable.admin.v2.models.Table.fromProto(tableProto))
             .map(tableAdapter2x::adapt)
             .collect(Collectors.toList())
       );

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -15,9 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase2_x;
 
-import static com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter.buildGarbageCollectionRule;
 import static com.google.cloud.bigtable.hbase2_x.FutureUtils.failedFuture;
-import static com.google.cloud.bigtable.hbase.util.ModifyTableBuilder.buildModifications;
 
 import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
 import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
@@ -234,6 +232,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
          r.stream()
             .filter(t -> !tableNamePattern.isPresent() ||
                 tableNamePattern.get().matcher(bigtableInstanceName.toTableId(t.getName())).matches())
+            .map(tableProto-> com.google.cloud.bigtable.admin.v2.models.Table.fromProto(tableProto))
             .map(tableAdapter2x::adapt)
             .collect(Collectors.toList())
       );
@@ -291,7 +290,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
           throw new CompletionException(ex);
         }
       } else {
-        return tableAdapter2x.adapt(resp);
+        return tableAdapter2x.adapt(com.google.cloud.bigtable.admin.v2.models.Table.fromProto(resp));
       }
     });
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TableAdapter2x.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.hbase2_x.adapters.admin;
 import com.google.api.core.InternalApi;
 
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.cloud.bigtable.grpc.BigtableInstanceName;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
@@ -25,7 +26,6 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
-import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.hbase.adapters.admin.ColumnDescriptorAdapter;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
@@ -63,7 +63,7 @@ public class TableAdapter2x {
   /**
    * <p>adapt.</p>
    *
-   * @param table a {@link com.google.bigtable.admin.v2.Table} object.
+   * @param table a {@link Table} object.
    * @return a {@link TableDescriptor} object.
    */
   public TableDescriptor adapt(Table table) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
@@ -18,16 +18,19 @@ package com.google.cloud.bigtable.hbase.com.google.cloud.bigtable.hbase2_x.adapt
 import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
 
 import com.google.bigtable.admin.v2.ColumnFamily;
-import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.GCRules;
+import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 import com.google.cloud.bigtable.hbase2_x.adapters.admin.TableAdapter2x;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Assert;
 import org.junit.Before;
@@ -79,9 +82,9 @@ public class TestTableAdapter2x {
     GCRules.GCRule gcRule = GCRULES.maxVersions(maxVersion);
     ColumnFamily columnFamily = ColumnFamily.newBuilder()
             .setGcRule(gcRule.toProto()).build();
-    Table table = Table.newBuilder()
+    Table table = Table.fromProto(com.google.bigtable.admin.v2.Table.newBuilder()
             .setName(TABLE_NAME)
-            .putColumnFamilies(COLUMN_FAMILY, columnFamily).build();
+            .putColumnFamilies(COLUMN_FAMILY, columnFamily).build());
     TableDescriptor actualTableDesc = tableAdapter2x.adapt(table);
 
     TableDescriptor expected = new HTableDescriptor(TableName.valueOf(TABLE_ID))

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
@@ -18,9 +18,9 @@ package com.google.cloud.bigtable.hbase.com.google.cloud.bigtable.hbase2_x.adapt
 import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
 
 import com.google.bigtable.admin.v2.ColumnFamily;
+import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.GCRules;
-import com.google.cloud.bigtable.admin.v2.models.Table;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 import com.google.cloud.bigtable.hbase2_x.adapters.admin.TableAdapter2x;
@@ -82,10 +82,11 @@ public class TestTableAdapter2x {
     GCRules.GCRule gcRule = GCRULES.maxVersions(maxVersion);
     ColumnFamily columnFamily = ColumnFamily.newBuilder()
             .setGcRule(gcRule.toProto()).build();
-    Table table = Table.fromProto(com.google.bigtable.admin.v2.Table.newBuilder()
+    Table table = Table.newBuilder()
             .setName(TABLE_NAME)
-            .putColumnFamilies(COLUMN_FAMILY, columnFamily).build());
-    TableDescriptor actualTableDesc = tableAdapter2x.adapt(table);
+            .putColumnFamilies(COLUMN_FAMILY, columnFamily).build();
+    TableDescriptor actualTableDesc = tableAdapter2x.adapt(
+        com.google.cloud.bigtable.admin.v2.models.Table.fromProto(table));
 
     TableDescriptor expected = new HTableDescriptor(TableName.valueOf(TABLE_ID))
             .addFamily(new HColumnDescriptor(COLUMN_FAMILY));


### PR DESCRIPTION
## What changes this PR contains
Preparing ColumnDescriptorAdapter & TableAdapter  to update with GCJ models.
 - Updated `ColumnDescriptorAdapter` to adapt to `models.ColumnFamily`.
 - Updated `TableAdapter` & `TableAdapter2x` to adapt to `models.Table`.
