### PR TITLE
Migration of RowAdapter with models.Row

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataClientWrapper.java
@@ -260,7 +260,7 @@ public class BigtableDataClientWrapper implements IBigtableDataClient {
    * @param response an instance of {@link ReadModifyWriteRowResponse} type.
    * @return an instance of {@link Row}.
    */
-  private Row transformResponse(ReadModifyWriteRowResponse response) {
+  public static Row transformResponse(ReadModifyWriteRowResponse response) {
     ImmutableList.Builder<RowCell> rowCells  = ImmutableList.builder();
 
     for (Family family : response.getRow().getFamiliesList()) {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableName.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableName.java
@@ -71,10 +71,6 @@ public class BigtableTableName {
     return tableId;
   }
 
-  public InstanceName toGcbInstanceName() {
-    return InstanceName.of(projectId, instanceId);
-  }
-
   /** {@inheritDoc} */
   @Override
   public String toString() {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -15,7 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import com.google.bigtable.v2.ReadModifyWriteRowResponse;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.grpc.BigtableDataClientWrapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,7 +37,6 @@ import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.coprocessor.Batch;
 
 import com.google.common.base.Preconditions;
-import com.google.bigtable.v2.ReadModifyWriteRowResponse;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableSession;
@@ -106,10 +107,12 @@ public class BatchExecutor {
       try {
         if (message instanceof FlatRow) {
           result = Adapters.FLAT_ROW_ADAPTER.adaptResponse((FlatRow) message);
-        } else if (message instanceof com.google.bigtable.v2.Row) {
-          result = Adapters.ROW_ADAPTER.adaptResponse((com.google.bigtable.v2.Row) message);
         } else if (message instanceof ReadModifyWriteRowResponse) {
-          result = Adapters.ROW_ADAPTER.adaptResponse(((ReadModifyWriteRowResponse) message).getRow());
+          com.google.cloud.bigtable.data.v2.models.Row row =
+              BigtableDataClientWrapper.transformResponse(((ReadModifyWriteRowResponse) message));
+          result = Adapters.ROW_ADAPTER.adaptResponse(row);
+        } else if (message instanceof com.google.cloud.bigtable.data.v2.models.Row) {
+          result = Adapters.ROW_ADAPTER.adaptResponse((com.google.cloud.bigtable.data.v2.models.Row) message);
         }
       } catch(Throwable throwable) {
         onFailure(throwable);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
-import com.google.cloud.bigtable.data.v2.models.InstanceName;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.MutationApi;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -37,8 +36,6 @@ import org.apache.hadoop.hbase.client.Scan;
 
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.bigtable.v2.MutateRowsRequest;
-import com.google.bigtable.v2.ReadModifyWriteRowRequest;
-import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
@@ -103,10 +100,8 @@ public class HBaseRequestAdapter {
     this(tableName,
         options.getInstanceName().toTableName(tableName.getQualifierAsString()),
         mutationAdapters,
-        RequestContext.create(
-            InstanceName.of(options.getProjectId(), options.getInstanceId()),
-            options.getAppProfileId()
-        ));
+        RequestContext
+            .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId()));
   }
 
 
@@ -171,54 +166,54 @@ public class HBaseRequestAdapter {
    * <p>adapt.</p>
    *
    * @param get a {@link Get} object.
-   * @return a {@link ReadRowsRequest} object.
+   * @return a {@link Query} object.
    */
-  public ReadRowsRequest adapt(Get get) {
+  public Query adapt(Get get) {
     ReadHooks readHooks = new DefaultReadHooks();
     Query query = Query.create(bigtableTableName.getTableId());
     Adapters.GET_ADAPTER.adapt(get, readHooks, query);
     readHooks.applyPreSendHook(query);
-    return query.toProto(requestContext);
+    return query;
   }
 
   /**
    * <p>adapt.</p>
    *
    * @param scan a {@link Scan} object.
-   * @return a {@link ReadRowsRequest} object.
+   * @return a {@link Query} object.
    */
-  public ReadRowsRequest adapt(Scan scan) {
+  public Query adapt(Scan scan) {
     ReadHooks readHooks = new DefaultReadHooks();
     Query query = Query.create(bigtableTableName.getTableId());
     Adapters.SCAN_ADAPTER.adapt(scan, readHooks, query);
     readHooks.applyPreSendHook(query);
-    return query.toProto(requestContext);
+    return query;
   }
 
   /**
    * <p>adapt.</p>
    *
-   * @param append a {@link org.apache.hadoop.hbase.client.Append} object.
-   * @return a {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} object.
+   * @param append a {@link Append} object.
+   * @return a {@link ReadModifyWriteRow} object.
    */
-  public ReadModifyWriteRowRequest adapt(Append append) {
+  public ReadModifyWriteRow adapt(Append append) {
     ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
         .create(bigtableTableName.getTableId(), ByteString.copyFrom(append.getRow()));
     Adapters.APPEND_ADAPTER.adapt(append, readModifyWriteRow);
-    return readModifyWriteRow.toProto(requestContext);
+    return readModifyWriteRow;
   }
 
   /**
    * <p>adapt.</p>
    *
-   * @param increment a {@link org.apache.hadoop.hbase.client.Increment} object.
-   * @return a {@link com.google.bigtable.v2.ReadModifyWriteRowRequest} object.
+   * @param increment a {@link Increment} object.
+   * @return a {@link ReadModifyWriteRow} object.
    */
-  public ReadModifyWriteRowRequest adapt(Increment increment) {
+  public ReadModifyWriteRow adapt(Increment increment) {
     ReadModifyWriteRow readModifyWriteRow = ReadModifyWriteRow
         .create(bigtableTableName.getTableId(), ByteString.copyFrom(increment.getRow()));
     Adapters.INCREMENT_ADAPTER.adapt(increment, readModifyWriteRow);
-    return readModifyWriteRow.toProto(requestContext);
+    return readModifyWriteRow;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowAdapter.java
@@ -15,21 +15,19 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.read;
 
-import com.google.bigtable.v2.Cell;
-import com.google.bigtable.v2.Column;
-import com.google.bigtable.v2.Family;
-import com.google.bigtable.v2.Row;
+import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.hbase.adapters.ResponseAdapter;
-import com.google.cloud.bigtable.hbase.util.TimestampConverter;
 import com.google.cloud.bigtable.hbase.util.ByteStringer;
+import com.google.cloud.bigtable.hbase.util.TimestampConverter;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
 
 /**
- * Adapt between a {@link com.google.bigtable.v2.Row} and an hbase client {@link org.apache.hadoop.hbase.client.Result}.
+ * Adapt between a {@link Row} and an hbase client {@link Result}.
  *
  * @author sduskis
  * @version $Id: $Id
@@ -46,38 +44,27 @@ public class RowAdapter implements ResponseAdapter<Row, Result> {
       return new Result();
     }
 
-    SortedSet<org.apache.hadoop.hbase.Cell> hbaseCells = new TreeSet<>(KeyValue.COMPARATOR);
+    SortedSet<Cell> hbaseCells = new TreeSet<>(KeyValue.COMPARATOR);
     byte[] rowKey = ByteStringer.extract(response.getKey());
-
-    for (Family family : response.getFamiliesList()) {
-      byte[] familyNameBytes = Bytes.toBytes(family.getName());
-
-      for (Column column : family.getColumnsList()) {
-        byte[] columnQualifier = ByteStringer.extract(column.getQualifier());
-
-        for (Cell cell : column.getCellsList()) {
-          // Cells with labels are for internal use, do not return them.
-          // TODO(kevinsi4508): Filter out targeted {@link WhileMatchFilter} labels.
-          if (cell.getLabelsCount() > 0) {
-            continue;
-          }
-
-          // Bigtable timestamp has more granularity than HBase one. It is possible that Bigtable
-          // cells are deduped unintentionally here. On the other hand, if we don't dedup them,
-          // HBase will treat them as duplicates.
-          long hbaseTimestamp = TimestampConverter.bigtable2hbase(cell.getTimestampMicros());
-          RowCell keyValue = new RowCell(
-              rowKey,
-              familyNameBytes,
-              columnQualifier,
-              hbaseTimestamp,
-              ByteStringer.extract(cell.getValue()));
-
-          hbaseCells.add(keyValue);
-        }
+    for (com.google.cloud.bigtable.data.v2.models.RowCell rowCell : response.getCells()) {
+      // Cells with labels are for internal use, do not return them.
+      // TODO(kevinsi4508): Filter out targeted {@link WhileMatchFilter} labels.
+      if (rowCell.getLabels().size() > 0) {
+        continue;
       }
+      byte[] familyNameBytes = Bytes.toBytes(rowCell.getFamily());
+      byte[] columnQualifier = ByteStringer.extract(rowCell.getQualifier());
+      long hbaseTimestamp = TimestampConverter.bigtable2hbase(rowCell.getTimestamp());
+      RowCell keyValue = new RowCell(
+          rowKey,
+          familyNameBytes,
+          columnQualifier,
+          hbaseTimestamp,
+          ByteStringer.extract(rowCell.getValue()));
+
+      hbaseCells.add(keyValue);
     }
 
-    return Result.create(hbaseCells.toArray(new org.apache.hadoop.hbase.Cell[hbaseCells.size()]));
+    return Result.create(hbaseCells.toArray(new Cell[hbaseCells.size()]));
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestRowAdapter.java
@@ -19,13 +19,13 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import com.google.bigtable.v2.Cell;
-import com.google.bigtable.v2.Column;
-import com.google.bigtable.v2.Family;
-import com.google.bigtable.v2.Row;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.data.v2.models.RowCell;
 import com.google.cloud.bigtable.hbase.util.ByteStringer;
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
-
+import java.util.Collections;
+import java.util.List;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
@@ -47,9 +47,7 @@ public class TestRowAdapter {
 
   @Test
   public void adaptResponse_emptyRow() {
-    Row row = Row.newBuilder()
-        .setKey(ByteString.copyFromUtf8("key"))
-        .build();
+    Row row = Row.create(ByteString.copyFromUtf8("key"), Collections.<RowCell>emptyList());
     Result result = instance.adaptResponse(row);
     assertEquals(0, result.rawCells().length);
   }
@@ -66,59 +64,49 @@ public class TestRowAdapter {
     byte[] value2 = "value2".getBytes();
     byte[] value3 = "value3".getBytes();
     byte[] value4 = "value4".getBytes();
-    byte[] value5 = "value5".getBytes();
- 
+
     ByteString key = ByteString.copyFromUtf8("key");
     final long ts1Micros = 54321L;
     final long ts2Micros = 12345L;
     final long ts1Millis = ts1Micros / 1000;
     final long ts2Millis = ts2Micros / 1000;
-    Row row = Row.newBuilder()
-        .setKey(key)
-        .addFamilies(Family.newBuilder()
-            .setName(family1)
-            .addColumns(Column.newBuilder()
-                .setQualifier(ByteString.copyFrom(qualifier1))
-                .addCells(Cell.newBuilder() // First cell.
-                    .setTimestampMicros(ts1Micros)
-                    .setValue(ByteString.copyFrom(value1)))
-                .addCells(Cell.newBuilder() // Same family, same column, but different timestamps.
-                  .setTimestampMicros(ts2Micros)
-                  .setValue(ByteString.copyFrom(value2)))
-                .addCells(Cell.newBuilder() // With label
-                    .setValue(ByteString.copyFromUtf8("withLabel"))
-                    .addLabels("label")))
-            .addColumns(Column.newBuilder()
-                .setQualifier(ByteString.copyFrom(qualifier2))
-                .addCells(Cell.newBuilder() // Same family, same timestamp, but different column.
-                    .setTimestampMicros(ts1Micros)
-                    .setValue(ByteString.copyFrom(value3)))))
-        .addFamilies(Family.newBuilder()
-            .setName(family2)
-            .addColumns(Column.newBuilder()
-                .setQualifier(ByteString.copyFrom(qualifier1))
-                .addCells(Cell.newBuilder() // Same column, same timestamp, but different family.
-                    .setTimestampMicros(ts1Micros)
-                    .setValue(ByteString.copyFrom(value4))))
-            .addColumns(Column.newBuilder()
-                .setQualifier(ByteString.copyFrom(qualifier2))
-                .addCells(Cell.newBuilder() // Same timestamp, but different family and column.
-                    .setTimestampMicros(ts1Micros)
-                    .setValue(ByteString.copyFrom(value5)))))
-        .build();
+    String label = "label";
+    List<String> labelList = Collections.emptyList();
 
-    Result result = instance.adaptResponse(row);
-    assertEquals(5, result.rawCells().length);
+    ImmutableList.Builder<RowCell> rowCells = ImmutableList.builder();
+    rowCells.add(RowCell.create(family1, ByteString.copyFrom(qualifier1), ts1Micros, labelList,
+        ByteString.copyFrom(value1)));
+    rowCells.add(RowCell.create(family1, ByteString.copyFrom(qualifier2), ts2Micros, labelList,
+        ByteString.copyFrom(value2)));
+    rowCells.add(RowCell.create(family2, ByteString.copyFrom(qualifier2), ts2Micros, labelList,
+        ByteString.copyFrom(value3)));
+    rowCells.add(RowCell.create(family2, ByteString.copyFrom(qualifier1), ts1Micros, labelList,
+        ByteString.copyFrom(value4)));
+
+    //Added duplicate row, should be ignored
+    rowCells.add(RowCell.create(family2, ByteString.copyFrom(qualifier1), ts1Micros, labelList,
+        ByteString.copyFrom(value4)));
+
+    //Row containing Label, Should be ignored
+    rowCells.add(RowCell.create(family1, ByteString.copyFrom(qualifier2), ts2Micros,
+        Collections.singletonList(label), ByteString.copyFrom(value1)));
+    Row inputRow = Row.create(key, rowCells.build());
+
+    Result result = instance.adaptResponse(inputRow);
+    assertEquals(4, result.rawCells().length);
 
     // The duplicate row and label cells have been removed. The timestamp micros get converted to
     // millisecond accuracy.
     byte[] keyArray = ByteStringer.extract(key);
     org.apache.hadoop.hbase.Cell[] expectedCells = new org.apache.hadoop.hbase.Cell[] {
-        new RowCell(keyArray, family1Bytes, qualifier1, ts1Millis, value1),
-        new RowCell(keyArray, family1Bytes, qualifier1, ts2Millis, value2),
-        new RowCell(keyArray, family1Bytes, qualifier2, ts1Millis, value3),
-        new RowCell(keyArray, family2Bytes, qualifier1, ts1Millis, value4),
-        new RowCell(keyArray, family2Bytes, qualifier2, ts1Millis, value5)
+        new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, family1Bytes,
+            qualifier1, ts1Millis, value1),
+        new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, family1Bytes,
+            qualifier2, ts2Millis, value2),
+        new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, family2Bytes,
+            qualifier1, ts1Millis, value3),
+        new com.google.cloud.bigtable.hbase.adapters.read.RowCell(keyArray, family2Bytes,
+            qualifier2, ts2Millis, value4),
     };
     assertArrayEquals(expectedCells, result.rawCells());
   }


### PR DESCRIPTION
## What changes this PR contains

Migration of RowAdapter with models.Row & related reference update.

Note: This change is on top of [PR#2058](https://github.com/GoogleCloudPlatform/cloud-bigtable-client/pull/2058). once that is merged, it can be rebased. 

***
**Doubt**: What is the reason for limiting request type of [AsyncExecutor#call](https://github.com/rahulKQL/cloud-bigtable-client/blob/master/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/AsyncExecutor.java#L239) to the subclass protobuf.MessageLite?
this is blocking me to update AsyncExecutor to utilize IBigtableDataClient(here all Request types are 
GCJ models type, which doesn't implement MessageLite