### PR TITLE
Updated HBaseRequestAdapter &  Batch executor with model

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -15,7 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -208,9 +210,9 @@ public class BatchExecutor {
       if (row instanceof Get) {
         return bulkOperation.bulkRead.add(requestAdapter.adapt((Get) row).toProto(requestContext));
       } else if (row instanceof Put) {
-        return bulkOperation.bulkMutation.add(requestAdapter.adaptEntry((Put) row));
+        return bulkOperation.bulkMutation.add(toEntry(requestAdapter.adaptEntry((Put) row)));
       } else if (row instanceof Delete) {
-        return bulkOperation.bulkMutation.add(requestAdapter.adaptEntry((Delete) row));
+        return bulkOperation.bulkMutation.add(toEntry(requestAdapter.adaptEntry((Delete) row)));
       } else if (row instanceof Append) {
         return asyncExecutor.readModifyWriteRowAsync(
             requestAdapter.adapt((Append) row).toProto(requestContext));
@@ -218,7 +220,7 @@ public class BatchExecutor {
         return asyncExecutor.readModifyWriteRowAsync(
             requestAdapter.adapt((Increment) row).toProto(requestContext));
       } else if (row instanceof RowMutations) {
-        return bulkOperation.bulkMutation.add(requestAdapter.adaptEntry((RowMutations) row));
+        return bulkOperation.bulkMutation.add(toEntry(requestAdapter.adaptEntry((RowMutations) row)));
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -345,5 +347,9 @@ public class BatchExecutor {
       exists[index] = !getResults[index].isEmpty();
     }
     return exists;
+  }
+
+  private MutateRowsRequest.Entry toEntry(RowMutation rowMutation) {
+    return rowMutation.toBulkProto(requestContext).getEntries(0);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -15,7 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -187,9 +189,9 @@ public class BigtableBufferedMutatorHelper {
         future = Futures.immediateFailedFuture(
           new IllegalArgumentException("Cannot perform a mutation on a null object."));
       } else if (mutation instanceof Put) {
-        future = bulkMutation.add(adapter.adaptEntry((Put) mutation));
+        future = bulkMutation.add(toEntry(adapter.adaptEntry((Put) mutation)));
       } else if (mutation instanceof Delete) {
-        future = bulkMutation.add(adapter.adaptEntry((Delete) mutation));
+        future = bulkMutation.add(toEntry(adapter.adaptEntry((Delete) mutation)));
       } else if (mutation instanceof Increment) {
         future =
             asyncExecutor.readModifyWriteRowAsync(
@@ -209,7 +211,6 @@ public class BigtableBufferedMutatorHelper {
     return future;
   }
 
-
   /**
    * <p>hasInflightRequests.</p>
    *
@@ -218,5 +219,9 @@ public class BigtableBufferedMutatorHelper {
   public boolean hasInflightRequests() {
     return this.asyncExecutor.hasInflightRequests()
         || (bulkMutation != null && !bulkMutation.isFlushed());
+  }
+
+  private MutateRowsRequest.Entry toEntry(RowMutation rowMutation) {
+    return rowMutation.toBulkProto(requestContext).getEntries(0);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.MutationApi;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -72,7 +71,6 @@ public class HBaseRequestAdapter {
   protected final MutationAdapters mutationAdapters;
   protected final TableName tableName;
   protected final BigtableTableName bigtableTableName;
-  protected final RequestContext requestContext;
 
   /**
    * <p>Constructor for HBaseRequestAdapter.</p>
@@ -97,9 +95,7 @@ public class HBaseRequestAdapter {
                              MutationAdapters mutationAdapters) {
     this(tableName,
         options.getInstanceName().toTableName(tableName.getQualifierAsString()),
-        mutationAdapters,
-        RequestContext
-            .create(options.getProjectId(), options.getInstanceId(), options.getAppProfileId()));
+        mutationAdapters);
   }
 
 
@@ -113,16 +109,14 @@ public class HBaseRequestAdapter {
   @VisibleForTesting
   HBaseRequestAdapter(TableName tableName,
                               BigtableTableName bigtableTableName,
-                              MutationAdapters mutationAdapters,
-                              RequestContext requestContext) {
+                              MutationAdapters mutationAdapters) {
     this.tableName = tableName;
     this.bigtableTableName = bigtableTableName;
     this.mutationAdapters = mutationAdapters;
-    this.requestContext = requestContext;
   }
 
   public HBaseRequestAdapter withServerSideTimestamps(){
-    return new HBaseRequestAdapter(tableName, bigtableTableName, mutationAdapters.withServerSideTimestamps(), requestContext);
+    return new HBaseRequestAdapter(tableName, bigtableTableName, mutationAdapters.withServerSideTimestamps());
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -34,8 +34,6 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Scan;
 
-import com.google.bigtable.v2.MutateRowRequest;
-import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
@@ -156,10 +154,10 @@ public class HBaseRequestAdapter {
    * @param delete a {@link org.apache.hadoop.hbase.client.Delete} object.
    * @return a {@link com.google.bigtable.v2.MutateRowsRequest.Entry} object.
    */
-  public MutateRowsRequest.Entry adaptEntry(Delete delete) {
+  public RowMutation adaptEntry(Delete delete) {
     RowMutation rowMutation = newRowMutationModel(delete.getRow());
     adapt(delete, rowMutation);
-    return toEntry(rowMutation);
+    return rowMutation;
   }
 
   /**
@@ -244,10 +242,10 @@ public class HBaseRequestAdapter {
    * @param put a {@link org.apache.hadoop.hbase.client.Put} object.
    * @return a {@link com.google.bigtable.v2.MutateRowsRequest.Entry} object.
    */
-  public MutateRowsRequest.Entry adaptEntry(Put put) {
+  public RowMutation adaptEntry(Put put) {
     RowMutation rowMutation = newRowMutationModel(put.getRow());
     adapt(put, rowMutation);
-    return toEntry(rowMutation);
+    return rowMutation;
   }
 
   /**
@@ -279,10 +277,10 @@ public class HBaseRequestAdapter {
    * @param mutations a {@link org.apache.hadoop.hbase.client.RowMutations} object.
    * @return a {@link com.google.bigtable.v2.MutateRowsRequest.Entry} object.
    */
-  public MutateRowsRequest.Entry adaptEntry(RowMutations mutations) {
+  public RowMutation adaptEntry(RowMutations mutations) {
     RowMutation rowMutation = newRowMutationModel(mutations.getRow());
     adapt(mutations, rowMutation);
-    return toEntry(rowMutation);
+    return rowMutation;
   }
 
   /**
@@ -291,10 +289,10 @@ public class HBaseRequestAdapter {
    * @param mutation a {@link org.apache.hadoop.hbase.client.Mutation} object.
    * @return a {@link com.google.bigtable.v2.MutateRowRequest} object.
    */
-  public MutateRowRequest adapt(org.apache.hadoop.hbase.client.Mutation mutation) {
+  public RowMutation adapt(org.apache.hadoop.hbase.client.Mutation mutation) {
     RowMutation rowMutation = newRowMutationModel(mutation.getRow());
     adapt(mutation, rowMutation);
-    return rowMutation.toProto(requestContext);
+    return rowMutation;
   }
 
   /**
@@ -335,10 +333,6 @@ public class HBaseRequestAdapter {
     return getBigtableTableName().toString();
   }
 
-  private MutateRowsRequest.Entry toEntry(RowMutation rowMutation) {
-    return rowMutation.toBulkProto(requestContext).getEntries(0);
-  }
-
   private RowMutation newRowMutationModel(byte [] rowKey) {
     if (!mutationAdapters.putAdapter.isSetClientTimestamp()) {
       return RowMutation.create(
@@ -348,5 +342,4 @@ public class HBaseRequestAdapter {
     }
     return RowMutation.create(bigtableTableName.getTableId(), ByteString.copyFrom(rowKey));
   }
-
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
@@ -75,11 +75,7 @@ public class TestCheckAndMutateUtil {
     requestAdapter = new HBaseRequestAdapter(
         TABLE_NAME,
         BT_TABLE_NAME,
-        mutationAdapters,
-        RequestContext.create(
-            InstanceName.of(BT_TABLE_NAME.getProjectId(), BT_TABLE_NAME.getInstanceId()),
-            "APP_PROFILE_ID"
-        ));
+        mutationAdapters);
   }
 
   private static void checkPredicate(CheckAndMutateRowRequest result) {


### PR DESCRIPTION
After this PR HBaseRequestAdapter will no longer have reference to proto models... all operations will support gcj's model.