### PR TITLE
Fixed Javadoc build with doclint

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableRegionLocator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableRegionLocator.java
@@ -72,6 +72,8 @@ public abstract class AbstractBigtableRegionLocator {
  
   /**
    * The list of regions will be sorted and cover all the possible rows.
+   * @param reload a boolean field.
+   * @return a {@link List} object.
    */
   protected synchronized ListenableFuture<List<HRegionLocation>> getRegionsAsync(boolean reload) {
     // If we don't need to refresh and we have a recent enough version, just use that.

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -67,7 +67,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
    * @param adapter Converts HBase objects to Bigtable protos
    * @param configuration For Additional configuration. TODO: move this to options
    * @param listener Handles exceptions. By default, it just throws the exception.
-   * @param session a {@link com.google.cloud.bigtable.grpc.BigtableSession} to get {@link com.google.cloud.bigtable.config.BigtableOptions}, {@link com.google.cloud.bigtable.grpc.async.AsyncExecutor}
+   * @param session a {@link com.google.cloud.bigtable.grpc.BigtableSession} to get {@link com.google.cloud.bigtable.config.BigtableOptions}
    * and {@link com.google.cloud.bigtable.grpc.async.BulkMutation} objects from
    * starting the async operations on the BigtableDataClient.
    */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -78,7 +78,6 @@ public class BigtableBufferedMutatorHelper {
    * @param configuration For Additional configuration. TODO: move this to options
    * @param session a {@link com.google.cloud.bigtable.grpc.BigtableSession} to get
    *          {@link com.google.cloud.bigtable.config.BigtableOptions},
-   *          {@link com.google.cloud.bigtable.grpc.async.AsyncExecutor} and
    *          {@link com.google.cloud.bigtable.grpc.async.BulkMutation} objects from starting the
    *          async operations on the BigtableDataClient.
    */
@@ -154,7 +153,8 @@ public class BigtableBufferedMutatorHelper {
    * Being a Mutation. This method will block if either of the following are true:
    * 1) There are more than {@code maxInflightRpcs} RPCs in flight
    * 2) There are more than {@link #getWriteBufferSize()} bytes pending
-   * @return 
+   * @param mutation a {@link Mutation} object.
+   * @return result of mutate(Mutation).
    */
   public ListenableFuture<?> mutate(final Mutation mutation) {
     closedReadLock.lock();
@@ -169,9 +169,8 @@ public class BigtableBufferedMutatorHelper {
   }
 
   /**
-   *
-   * @param mutation
-   * @return
+   * @param mutation a {@link RowMutations} object.
+   * @return result of mutate operation.
    */
   public ListenableFuture<?> mutate(final RowMutations mutation) {
     closedReadLock.lock();

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableConfiguration.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableConfiguration.java
@@ -127,7 +127,7 @@ public class BigtableConfiguration {
    *
    * @param conf a {@link org.apache.hadoop.conf.Configuration} object to configure.
    * @param credentials a {@link Credentials} object;
-   * @return
+   * @return a {@link Configuration} object.
    */
   public static Configuration withCredentials(Configuration conf, Credentials credentials) {
     return new BigtableExtendedConfiguration(conf, credentials);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableExtendedScan.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableExtendedScan.java
@@ -57,7 +57,7 @@ public class BigtableExtendedScan extends Scan {
 
   /**
    * Creates a {@link RowRange} based on a prefix.  This is similar to {@link Scan#setRowPrefixFilter(byte[])}.
-   * @param prefix
+   * @param prefix a byte array.
    */
   public void addRangeWithPrefix(byte[] prefix) {
     addRange(prefix, RowKeyUtil.calculateTheClosestNextRowKeyForPrefix(prefix));
@@ -67,8 +67,8 @@ public class BigtableExtendedScan extends Scan {
    * Adds a range to scan. This is similar to calling a combination of
    * {@link Scan#setStartRow(byte[])} and {@link Scan#setStopRow(byte[])}. Other ranges can be
    * constructed by creating a {@link RowRange} and calling {@link #addRange(RowRange)}
-   * @param startRow
-   * @param stopRow
+   * @param startRow a byte array.
+   * @param stopRow a byte array.
    */
   public void addRange(byte[] startRow, byte[] stopRow) {
     addRange(RowRange.newBuilder()
@@ -81,7 +81,7 @@ public class BigtableExtendedScan extends Scan {
    * Adds an arbitrary {@link RowRange} to the request. Ranges can have empty start keys or end
    * keys. Ranges can also be inclusive/closed or exclusive/open. The default range is inclusive
    * start and exclusive end.
-   * @param range
+   * @param range a {@link RowRange} object.
    */
   public void addRange(RowRange range) {
     rowSet.addRowRanges(range);
@@ -92,7 +92,7 @@ public class BigtableExtendedScan extends Scan {
    * Duplicate rowKeys will result in a single response in the scan results. Results of scans also
    * return rows in lexicographically sorted order, and not based on the order in which row keys
    * were added.
-   * @param rowKey
+   * @param rowKey a byte array.
    */
   public void addRowKey(byte[] rowKey) {
     rowSet.addRowKeys(ByteStringer.wrap(rowKey));

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
@@ -150,7 +150,7 @@ public class CheckAndMutateUtil {
      * though HBase will still treat it as non-existence.
      *
      * @param compareOp a {@link CompareOp}
-     * @param value
+     * @param value a byte array.
      * @return this
      */
     public RequestBuilder ifMatches(CompareOp compareOp, @Nullable byte[] value) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/SampledRowKeysAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/SampledRowKeysAdapter.java
@@ -92,6 +92,10 @@ public abstract class SampledRowKeysAdapter {
    * {@link HRegionLocation} uses RegionInfo instead of {@link HRegionInfo}, causing confusion and
    * delay. {@link AbstractBigtableConnection#getRegionLocator(TableName)} calls an abstract method
    * which subclasses will construct appropriate {@link SampledRowKeysAdapter} implementations.
+   *
+   * @param startKey a byte array.
+   * @param endKey a byte array.
+   * @return a {@link HRegionLocation} object.
    */
   protected abstract HRegionLocation createRegionLocation(byte[] startKey, byte[] endKey);
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableWhileMatchResultScannerAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableWhileMatchResultScannerAdapter.java
@@ -110,6 +110,8 @@ public class BigtableWhileMatchResultScannerAdapter {
   /**
    * Returns {@code true} iff there are matching {@link WhileMatchFilter} labels or no {@link
    * WhileMatchFilter} labels.
+   * @param row a {@link FlatRow} object.
+   * @return a boolean value.
    */
   public static boolean hasMatchingLabels(FlatRow row) {
     int inLabelCount = 0;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/SingleColumnValueFilterAdapter.java
@@ -138,9 +138,10 @@ public class SingleColumnValueFilterAdapter
    *   ]
    * </pre>
    *
+   * <p>
    * NOTE: This logic can also be expressed as nested predicates, but that approach creates really poor
    * performance on the server side.
-   * <p>
+   * </p>
    */
   @Override
   public Filter adapt(FilterAdapterContext context, SingleColumnValueFilter filter)

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampFilterUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampFilterUtil.java
@@ -27,6 +27,8 @@ public class TimestampFilterUtil {
 
   /**
    * Converts an HBase timestamp in milliseconds to a Cloud Bigtable timestamp in Microseconds.
+   * @param timestamp a long value.
+   * @return a long value.
    */
   public static long hbaseToBigtableTimeUnit(long timestamp) {
     return BigtableConstants.BIGTABLE_TIMEUNIT.convert(
@@ -35,6 +37,10 @@ public class TimestampFilterUtil {
 
   /**
    * Converts a [startMs, endMs) timestamps to a Cloud Bigtable [startMicros, endMicros) filter.
+   *
+   * @param hbaseStartTimestamp a long value.
+   * @param hbaseEndTimestamp a long value.
+   * @return a {@link Filter} object.
    */
   public static Filter hbaseToTimestampRangeFilter(long hbaseStartTimestamp,
       long hbaseEndTimestamp) {
@@ -45,6 +51,10 @@ public class TimestampFilterUtil {
   /**
    * Converts a [startMicros, endNons) timestamps to a Cloud Bigtable [startMicros, endMicros)
    * filter.
+   *
+   * @param bigtableStartTimestamp a long value.
+   * @param bigtableEndTimestamp
+   * @return a {@link Filter} object.
    */
   public static Filter toTimestampRangeFilter(long bigtableStartTimestamp,
       long bigtableEndTimestamp) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampFilterUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TimestampFilterUtil.java
@@ -53,7 +53,7 @@ public class TimestampFilterUtil {
    * filter.
    *
    * @param bigtableStartTimestamp a long value.
-   * @param bigtableEndTimestamp
+   * @param bigtableEndTimestamp a long value.
    * @return a {@link Filter} object.
    */
   public static Filter toTimestampRangeFilter(long bigtableStartTimestamp,

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/TypedFilterAdapter.java
@@ -54,6 +54,8 @@ public interface TypedFilterAdapter<S extends Filter> {
    * Get hints how to optimize the scan. For example if the filter will narrow the scan using
    * the prefix "ab" then we can restrict the scan to ["ab" - "ac"). If the filter doesn't narrow
    * the scan then it should return Range.all()
+   * @param filter a {@link S} object.
+   * @return a {@link RangeSet} object.
    */
   RangeSet<RowKeyWrapper> getIndexScanHint(S filter);
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ScanAdapter.java
@@ -84,6 +84,7 @@ public class ScanAdapter implements ReadOperationAdapter<Scan> {
    * <p>Constructor for ScanAdapter.</p>
    *
    * @param filterAdapter a {@link FilterAdapter} object.
+   * @param rowRangeAdapter a {@link RowRangeAdapter} object.
    */
   public ScanAdapter(FilterAdapter filterAdapter, RowRangeAdapter rowRangeAdapter) {
     this.filterAdapter = filterAdapter;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/ByteStringer.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/ByteStringer.java
@@ -49,6 +49,8 @@ public class ByteStringer {
 
   /**
    * Wraps a byte array in a {@link ByteString} without copying it.
+   * @param array an array object.
+   * @return this
    */
   public static ByteString wrap(final byte[] array) {
     return USE_ZEROCOPYBYTESTRING? ZeroCopyByteStringUtil.wrap(array): ByteString.copyFrom(array);
@@ -56,6 +58,10 @@ public class ByteStringer {
 
   /**
    * Wraps a byte array in a {@link ByteString} without copying it.
+   * @param array  an array value.
+   * @param offset an integer value.
+   * @param length an integer value.
+   * @return this
    */
   public static ByteString wrap(final byte[] array, int offset, int length) {
     if (USE_ZEROCOPYBYTESTRING && offset == 0 && length == array.length) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/ModifyTableBuilder.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/util/ModifyTableBuilder.java
@@ -54,6 +54,9 @@ public class ModifyTableBuilder {
    * This method will build {@link ModifyColumnFamiliesRequest} objects based on a diff of the
    * new and existing set of column descriptors.  This is for use in
    * {@link org.apache.hadoop.hbase.client.Admin#modifyTable(TableName, HTableDescriptor)}.
+   * @param newTableDesc a {@link HTableDescriptor} object.
+   * @param currentTableDesc a {@link HTableDescriptor} object.
+   * @return this
    */
   public static ModifyTableBuilder buildModifications(
           HTableDescriptor newTableDesc,

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -106,7 +106,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
    * Constructor for AbstractBigtableAdmin.
    * </p>
    * @param connection a {@link CommonConnection} object.
-   * @throws IOException
+   * @throws IOException if any.
    */
   public AbstractBigtableAdmin(CommonConnection connection) throws IOException {
     LOG.debug("Creating BigtableAdmin");
@@ -321,6 +321,9 @@ public abstract class AbstractBigtableAdmin implements Admin {
   }
 
   /**
+   * To create Table.
+   *
+   * @param tableName a {@link TableName} object.
    * @param request a {@link CreateTableRequest} object to send.
    * @throws java.io.IOException if any.
    */
@@ -343,6 +346,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
   /**
    * @param tableName a {@link TableName} object for exception identification.
    * @param request a {@link CreateTableRequest} object to send.
+   * @return a {@link ListenableFuture} object.
    * @throws java.io.IOException if any.
    */
   protected ListenableFuture<Table> createTableAsync(final TableName tableName,
@@ -617,6 +621,10 @@ public abstract class AbstractBigtableAdmin implements Admin {
   /**
    * Modify an existing column family on a table.  NOTE: this is needed for backwards compatibility
    * for the hbase shell.
+   *
+   * @param tableName a {@link TableName} object.
+   * @param descriptor a {@link HColumnDescriptor} object.
+   * @throws java.io.IOException if any.
    */
   public void modifyColumns(final String tableName, HColumnDescriptor descriptor)
       throws IOException {
@@ -809,7 +817,13 @@ public abstract class AbstractBigtableAdmin implements Admin {
 
   // ------------ SNAPSHOT methods begin
 
-  /** {@inheritDoc} */
+  /**
+   * Creates a snapshot from an existing table.  NOTE: Cloud Bigtable has a cleanup policy
+   *
+   * @param snapshotName a {@link String} object.
+   * @param tableName a {@link TableName} object.
+   * @throws IOException if any.
+   */
   @Override
   public void snapshot(String snapshotName, TableName tableName)
       throws IOException, SnapshotCreationException, IllegalArgumentException {
@@ -825,10 +839,10 @@ public abstract class AbstractBigtableAdmin implements Admin {
   /**
    * Creates a snapshot from an existing table.  NOTE: Cloud Bigtable has a cleanup policy
    *
-   * @param snapshotName
-   * @param tableName
-   * @return
-   * @throws IOException
+   * @param snapshotName a {@link String} object.
+   * @param tableName a {@link TableName} object.
+   * @return a {@link Operation} object.
+   * @throws IOException if any.
    */
   protected Operation snapshotTable(String snapshotName, TableName tableName)
       throws IOException {
@@ -851,33 +865,53 @@ public abstract class AbstractBigtableAdmin implements Admin {
     return Futures.getChecked(future, IOException.class);
   }
 
-  /** This is needed for the hbase shell */
+  /**
+   * This is needed for the hbase shell.
+   *
+   * @param snapshotName a byte array object.
+   * @param tableName a byte array object.
+   * @throws IOException if any.
+   */
   public void snapshot(byte[] snapshotName, byte[] tableName)
-      throws IOException, SnapshotCreationException, IllegalArgumentException {
+      throws IOException, IllegalArgumentException {
     snapshot(snapshotName, TableName.valueOf(tableName));
   }
 
   /** {@inheritDoc} */
   @Override
   public void snapshot(byte[] snapshotName, TableName tableName)
-      throws IOException, SnapshotCreationException, IllegalArgumentException {
+      throws IOException, IllegalArgumentException {
     snapshot(Bytes.toString(snapshotName), tableName);
   }
 
-  /** This is needed for the hbase shell */
+  /**
+   * This is needed for the hbase shell.
+   *
+   * @param snapshotName a byte array object.
+   * @param tableName a byte array object.
+   * @throws IOException if any.
+   */
   public void cloneSnapshot(byte[] snapshotName, byte[] tableName)
-      throws IOException, TableExistsException, RestoreSnapshotException {
+      throws IOException {
     cloneSnapshot(snapshotName, TableName.valueOf(tableName));
   }
 
-  /** {@inheritDoc} */
+  /**
+   * @param snapshotName a {@link String} object.
+   * @param tableName a {@link TableName} object.
+   * @throws IOException if any.
+   */
   @Override
   public void cloneSnapshot(byte[] snapshotName, TableName tableName)
       throws IOException, TableExistsException, RestoreSnapshotException {
     cloneSnapshot(Bytes.toString(snapshotName), tableName);
   }
 
-  /** {@inheritDoc} */
+  /**
+   * @param snapshotName a {@link String} object.
+   * @param tableName a {@link TableName} object.
+   * @throws IOException if any.
+   */
   @Override
   public void cloneSnapshot(String snapshotName, TableName tableName)
       throws IOException, TableExistsException, RestoreSnapshotException {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -253,6 +253,10 @@ public abstract class AbstractBigtableConnection implements Connection, CommonCo
   /**
    * There are some hbase 1.x and 2.x incompatibilities which require this abstract method. See
    * {@link SampledRowKeysAdapter} for more details.
+   *
+   * @param tableName a {@link TableName} object.
+   * @param serverName a {@link ServerName} object.
+   * @return a {@link SampledRowKeysAdapter} object.
    */
   protected abstract SampledRowKeysAdapter createSampledRowKeysAdapter(TableName tableName,
     ServerName serverName);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
@@ -32,6 +32,7 @@ public interface CommonConnection extends Closeable {
   /**
    * Returns the {@link Configuration} object used by this instance. The
    * reference returned is not a copy, so any change made to it will affect this instance.
+   * @return a {@link Configuration} object.
    */
   Configuration getConfiguration();
 
@@ -55,6 +56,7 @@ public interface CommonConnection extends Closeable {
    * Retrieve a region information on a table.
    * @param tableName Name of the table for which to return region info.
    * @return A {@link java.util.List} HRegionInfo object
+   * @throws  java.io.IOException if any.
    */
   List<HRegionInfo> getAllRegionInfos(TableName tableName) throws IOException;
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTableAdminClient.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableTableAdminClient.java
@@ -53,6 +53,7 @@ public class BigtableTableAdminClient {
    * families, specified in the request.
    *
    * @param request a {@link CreateTableRequest} object.
+   * @return a {@link CompletableFuture} that returns a {@link Table} object.
    */
   public CompletableFuture<Table> createTableAsync(CreateTableRequest request) {
     return toCompletableFuture(adminClientWrapper.createTableAsync(request));
@@ -141,6 +142,7 @@ public class BigtableTableAdminClient {
   /**
    * Permanently deletes the specified snapshot.
    * @param request a {@link DeleteSnapshotRequest} object.
+   * @return a {@link CompletableFuture} object.
    */
   public CompletableFuture<Void> deleteSnapshotAsync(DeleteSnapshotRequest request) {
     return toCompletableFuture(adminClientWrapper.deleteSnapshotAsync(request));


### PR DESCRIPTION
After this change, Javadoc build passes although there are still warning to be fixed.
Except for `bigtable-client-core` module, Now no other module should give Javadoc warning.

Partially fixes #1986