### PR TITLE
Transform ListeanableFuture to ApiFuture for BulkMutation

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.core;
 
+import com.google.api.core.ApiFuture;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
@@ -43,11 +44,10 @@ public interface IBulkMutation {
    * Adds a {@link RowMutation} to the underlying IBulkMutation mechanism.
    *
    * @param rowMutation The {@link RowMutation} to add.
-   * @return a {@link ListenableFuture} of type {@link Void} will be set when request is
-   *     successful otherwise exception will be thrown.
+   * @return a {@link ApiFuture} of type {@link Void} will be set when request is
+   * successful otherwise exception will be thrown.
    */
-  //TODO(rahulkql): Once it is adapted to v2.models, change the return type to ApiFuture.
-  ListenableFuture<Void> add(RowMutation rowMutation);
+  ApiFuture<Void> add(RowMutation rowMutation);
 
   /**
    * Performs a {@link IBigtableDataClient#readModifyWriteRowAsync(ReadModifyWriteRow)} on the
@@ -55,8 +55,7 @@ public interface IBulkMutation {
    * {@link OperationAccountant#registerOperation(ListenableFuture)} blocks.
    *
    * @param request The {@link ReadModifyWriteRow} to send.
-   * @return a {@link ListenableFuture} which can be listened to for completion events.
+   * @return a {@link ApiFuture} which can be listened to for completion events.
    */
-  //TODO(rahulkql): Once it is adapted to v2.models, change the return type to ApiFuture.
-  ListenableFuture<Row> readModifyWrite(ReadModifyWriteRow request);
+  ApiFuture<Row> readModifyWrite(ReadModifyWriteRow request);
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
@@ -15,16 +15,15 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import com.google.api.core.ApiFuture;
 import com.google.bigtable.v2.MutateRowResponse;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.util.ApiFutureUtil;
 import com.google.common.base.Function;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.MoreExecutors;
 
 /**
  * This class wraps existing {@link com.google.cloud.bigtable.grpc.async.BulkMutation} with
@@ -60,19 +59,19 @@ public class BulkMutationWrapper implements IBulkMutation {
 
   /** {@inheritDoc} */
   @Override
-  public ListenableFuture<Void> add(RowMutation rowMutation) {
-    return Futures.transform(delegate.add(rowMutation.toBulkProto(requestContext).getEntries(0)),
+  public ApiFuture<Void> add(RowMutation rowMutation) {
+    return ApiFutureUtil.transformAndAdapt(delegate.add(rowMutation.toBulkProto(requestContext).getEntries(0)),
         new Function<MutateRowResponse, Void>() {
           @Override
           public Void apply(MutateRowResponse response) {
             return null;
           }
-        }, MoreExecutors.directExecutor());
+        });
   }
 
   /** {@inheritDoc} */
   @Override
-  public ListenableFuture<Row> readModifyWrite(ReadModifyWriteRow request) {
-    return delegate.readModifyWrite(request);
+  public ApiFuture<Row> readModifyWrite(ReadModifyWriteRow request) {
+    return ApiFutureUtil.adapt(delegate.readModifyWrite(request));
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import java.util.Collections;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.junit.Before;
 import org.junit.Test;
@@ -90,13 +91,13 @@ import static org.mockito.Mockito.when;
   }
 
   @Test
-  public void testReadModifyRow() {
+  public void testReadModifyRow() throws InterruptedException, ExecutionException {
     ReadModifyWriteRow readModifyRow = ReadModifyWriteRow.create("tableId", "test-key");
     ListenableFuture<Row> expectedResponse = Futures.immediateFuture(
         Row.create(ByteString.copyFromUtf8("test-key"), Collections.<RowCell>emptyList()));
     when(mockDelegate.readModifyWrite(readModifyRow)).thenReturn(expectedResponse);
     Future<Row> actualResponse = bulkWrapper.readModifyWrite(readModifyRow);
-    assertEquals(expectedResponse, actualResponse);
+    assertEquals(expectedResponse.get(), actualResponse.get());
     verify(mockDelegate).readModifyWrite(readModifyRow);
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkRead.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkRead.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.api.core.ApiFuture;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,8 +46,6 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import com.google.bigtable.v2.MutateRowsRequest;
-import com.google.bigtable.v2.ReadRowsRequest;
-import com.google.bigtable.v2.RowSet;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
@@ -99,7 +98,7 @@ public class TestBulkRead {
     when(mockClient.readFlatRows(any(Query.class))).thenReturn(mockScanner);
     FlatRow row = createRow(ByteString.copyFromUtf8("Key"));
     when(mockScanner.next()).thenReturn(row).thenReturn(null);
-    ListenableFuture<FlatRow> future = underTest.add(createRequest(row.getRowKey()));
+    ApiFuture<FlatRow> future = underTest.add(createRequest(row.getRowKey()));
     underTest.flush();
     verify(mockClient, times(1)).readFlatRows(any(Query.class));
     Assert.assertEquals(row, future.get(10, TimeUnit.MILLISECONDS));
@@ -114,8 +113,8 @@ public class TestBulkRead {
     FlatRow row = createRow(ByteString.copyFromUtf8("Key"));
     when(mockScanner.next()).thenReturn(row).thenReturn(null);
     Query request = createRequest(row.getRowKey());
-    ListenableFuture<FlatRow> future1 = underTest.add(request);
-    ListenableFuture<FlatRow> future2 = underTest.add(request);
+    ApiFuture<FlatRow> future1 = underTest.add(request);
+    ApiFuture<FlatRow> future2 = underTest.add(request);
     underTest.flush();
     verify(mockClient, times(1)).readFlatRows(any(Query.class));
     Assert.assertEquals(row, future1.get(10, TimeUnit.MILLISECONDS));
@@ -128,7 +127,7 @@ public class TestBulkRead {
   @Test
   public void testBatchOfOneHundred() throws Exception {
     List<ByteString> rowKeys = createRandomKeys(100);
-    List<ListenableFuture<FlatRow>> futures =
+    List<ApiFuture<FlatRow>> futures =
         addRows(rowKeys, new Answer<ResultScanner<FlatRow>>() {
           @Override
           public ResultScanner<FlatRow> answer(InvocationOnMock invocation) throws Throwable {
@@ -153,7 +152,7 @@ public class TestBulkRead {
   public void testMissingResponses() throws Exception {
     List<ByteString> rowKeys = createRandomKeys(100);
     final Set<ByteString> missing = new HashSet<>();
-    List<ListenableFuture<FlatRow>> futures = addRows(rowKeys, new Answer<ResultScanner<FlatRow>>() {
+    List<ApiFuture<FlatRow>> futures = addRows(rowKeys, new Answer<ResultScanner<FlatRow>>() {
       @Override
       public ResultScanner<FlatRow> answer(InvocationOnMock invocation) throws Throwable {
         Query request = invocation.getArgumentAt(0, Query.class);
@@ -184,12 +183,12 @@ public class TestBulkRead {
    * @param scannerGenerator Generates {@link ResultScanner}s that will generate FlatRows to be
    *     processed by {@link BulkRead}.
    */
-  private List<ListenableFuture<FlatRow>> addRows(
+  private List<ApiFuture<FlatRow>> addRows(
       List<ByteString> rowKeys, Answer<ResultScanner<FlatRow>> scannerGenerator) {
     when(mockClient.readFlatRows(any(Query.class)))
         .thenAnswer(scannerGenerator);
 
-    List<ListenableFuture<FlatRow>> futures = new ArrayList<>();
+    List<ApiFuture<FlatRow>> futures = new ArrayList<>();
     for (ByteString key : rowKeys) {
       futures.add(underTest.add(createRequest(key)));
     }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -15,6 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,9 +33,6 @@ import org.apache.hadoop.hbase.client.Row;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 
 /**
@@ -115,7 +115,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
   @Override
   public void mutate(List<? extends Mutation> mutations) throws IOException {
     handleExceptions();
-    List<ListenableFuture<?>> futures = helper.mutate(mutations);
+    List<ApiFuture<?>> futures = helper.mutate(mutations);
     for (int i = 0; i < mutations.size(); i++) {
       addCallback(futures.get(i), mutations.get(i));
     }
@@ -146,8 +146,8 @@ public class BigtableBufferedMutator implements BufferedMutator {
   }
 
   @SuppressWarnings("unchecked")
-  private void addCallback(ListenableFuture<?> future, Mutation mutation) {
-    Futures.addCallback(future, new ExceptionCallback(mutation), MoreExecutors.directExecutor());
+  private void addCallback(ApiFuture<?> future, Mutation mutation) {
+    ApiFutures.addCallback(future, new ExceptionCallback(mutation), MoreExecutors.directExecutor());
   }
 
   /**
@@ -198,7 +198,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
   }
 
   @SuppressWarnings("rawtypes")
-  private class ExceptionCallback implements FutureCallback {
+  private class ExceptionCallback implements ApiFutureCallback {
     private final Row mutation;
 
     public ExceptionCallback(Row mutation) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.api.core.ApiFutures;
+import com.google.api.core.SettableApiFuture;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import java.io.IOException;
@@ -50,8 +52,6 @@ import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.SettableFuture;
 
 /**
  * Tests for {@link BigtableBufferedMutator}
@@ -71,7 +71,7 @@ public class TestBigtableBufferedMutator {
   private IBulkMutation mockBulkMutation;
 
   @SuppressWarnings("rawtypes")
-  private SettableFuture future = SettableFuture.create();
+  private SettableApiFuture future = SettableApiFuture.create();
 
   @Mock
   private BufferedMutator.ExceptionListener listener;
@@ -145,7 +145,7 @@ public class TestBigtableBufferedMutator {
   @Test
   public void testInvalidPut() throws Exception {
     when(mockBulkMutation.add(any(RowMutation.class)))
-        .thenReturn(Futures.<Void> immediateFailedFuture(new RuntimeException()));
+        .thenReturn(ApiFutures.<Void> immediateFailedFuture(new RuntimeException()));
     BigtableBufferedMutator underTest = createMutator(new Configuration(false));
     underTest.mutate(SIMPLE_PUT);
     // Leave some time for the async worker to handle the request.


### PR DESCRIPTION
Transform `ListeanableFuture` to `ApiFuture` for
 -`IBulkMutation`'s operations.
 - `BulkRead#add`' operation.
 - `BatchExecutor#issueAsyncRowRequests` operation.
 - `BigtableBufferedMutatorHelper#mutate` operation.
 - Adapted ApiFuture in `BigtableBufferedMutator` as well.
 - Implemented `ApiFutureUtil#successfulAsList`.