### PR TITLE
Shifted to GCJ BigtableTableAdminClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ maven repository. When you disable that profile, attach workspace sources to the
 | Name | Language | Repository | latest version | status |
 | --- | --- | --- | --- | --- |
 | Cloud Bigtable Examples | Java, others | [GoogleCloudPlatform/cloud-bigtable-examples][maven-examples-repo] | | |
-| HBase client | Java | [GoogleCloudPlatform/cloud-bigtable-client][maven-hbase-client-repo] | [![Maven][maven-hbase-shield]][maven-hbase-client-maven-search] | GA |
+| HBase client | Java | [googleapis/cloud-bigtable-client][maven-hbase-client-repo] | [![Maven][maven-hbase-shield]][maven-hbase-client-maven-search] | GA |
 | Cloud Bigtable GoLang | Go | [googleapis/google-cloud-go](https://github.com/googleapis/google-cloud-go) | N/A | GA |
 | Cloud Bigtable Java | java | [googleapis/google-cloud-java](http://github.com/googleapis/google-cloud-java) | [![Maven][maven-google-cloud-java-shield]][maven-google-cloud-java-maven-search] | Beta |
 | Cloud Bigtable Python | Python | [googleapis/google-cloud-python](http://github.com/googleapis/google-cloud-python) | [![PyPI version](https://badge.fury.io/py/google-cloud-bigtable.svg)](https://badge.fury.io/py/google-cloud-bigtable) | Beta |
@@ -146,8 +146,8 @@ Apache 2.0; see [LICENSE](LICENSE) for details.
 
 <!-- references -->
 
-[travis-shield]: https://travis-ci.org/GoogleCloudPlatform/cloud-bigtable-client.svg
-[travis-link]: https://travis-ci.org/GoogleCloudPlatform/cloud-bigtable-client/builds
+[travis-shield]: https://travis-ci.org/googleapis/cloud-bigtable-client.svg
+[travis-link]: https://travis-ci.org/googleapis/cloud-bigtable-client/builds
 [maven-hbase-shield]: https://maven-badges.herokuapp.com/maven-central/com.google.cloud.bigtable/bigtable-client-core/badge.svg
 [maven-hbase-client-maven-search]: http://search.maven.org/#search%7Cga%7C1%7Ccom.google.cloud.bigtable
 [maven-google-cloud-java-shield]: https://maven-badges.herokuapp.com/maven-central/com.google.cloud/google-cloud-bigtable/badge.svg
@@ -157,7 +157,7 @@ Apache 2.0; see [LICENSE](LICENSE) for details.
 [stackoverflow-shield]: https://img.shields.io/badge/stackoverflow-google--cloud--bigtable-blue.svg
 [stackoverflow-link]: http://stackoverflow.com/search?q=[google-cloud-bigtable]
 [integrations]: https://cloud.google.com/bigtable/docs/integrations
-[maven-hbase-client-repo]: https://github.com/GoogleCloudPlatform/cloud-bigtable-client
+[maven-hbase-client-repo]: https://github.com/googleapis/cloud-bigtable-client
 [maven-bigtable-nodejs-repo]: https://github.com/googleapis/nodejs-bigtable
 [maven-examples-repo]: https://github.com/GoogleCloudPlatform/cloud-bigtable-examples
 [google-cloud-bigtable-discuss]: https://groups.google.com/group/google-cloud-bigtable-discuss

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -60,6 +60,8 @@ public class BigtableOptions implements Serializable, Cloneable {
   /** Constant <code>BIGTABLE_APP_PROFILE_DEFAULT=""</code>, defaults to the server default app profile */
   public static final String BIGTABLE_APP_PROFILE_DEFAULT = "";
 
+  public static final String BIGTABLE_CLIENT_ADAPTER = "BIGTABLE_CLIENT_ADAPTER";
+
   private static final Logger LOG = new Logger(BigtableOptions.class);
 
   private static int getDefaultDataChannelCount() {
@@ -96,6 +98,7 @@ public class BigtableOptions implements Serializable, Cloneable {
       options.dataChannelCount = BIGTABLE_DATA_CHANNEL_COUNT_DEFAULT;
       options.usePlaintextNegotiation = false;
       options.useCachedDataPool = false;
+      options.useGCJClient = false;
 
       options.retryOptions = new RetryOptions.Builder().build();
       options.callOptionsConfig = new CallOptionsConfig.Builder().build();
@@ -194,6 +197,11 @@ public class BigtableOptions implements Serializable, Cloneable {
 
     public Builder setUseBatch(boolean useBatch) {
       options.useBatch = useBatch;
+      return this;
+    }
+
+    public Builder setUseGCJClient(boolean useGCJClient){
+      options.useGCJClient = useGCJClient;
       return this;
     }
 
@@ -298,6 +306,7 @@ public class BigtableOptions implements Serializable, Cloneable {
   private int dataChannelCount;
   private boolean usePlaintextNegotiation;
   private boolean useCachedDataPool;
+  private boolean useGCJClient;
 
   private BigtableInstanceName instanceName;
 
@@ -438,6 +447,15 @@ public class BigtableOptions implements Serializable, Cloneable {
     return callOptionsConfig;
   }
 
+  /**
+   * <p>useGCJClient</p>
+   *
+   * @return a boolean flag to decide which client to use for Data & Admin Operations.
+   */
+  public boolean useGCJClient() {
+    return useGCJClient;
+  }
+
   /** {@inheritDoc} */
   @Override
   public boolean equals(Object obj) {
@@ -462,7 +480,8 @@ public class BigtableOptions implements Serializable, Cloneable {
         && Objects.equals(retryOptions, other.retryOptions)
         && Objects.equals(bulkOptions, other.bulkOptions)
         && Objects.equals(callOptionsConfig, other.callOptionsConfig)
-        && Objects.equals(useBatch, other.useBatch);
+        && Objects.equals(useBatch, other.useBatch)
+        && Objects.equals(useGCJClient, other.useGCJClient);
   }
 
   /** {@inheritDoc} */
@@ -485,6 +504,7 @@ public class BigtableOptions implements Serializable, Cloneable {
         .add("usePlaintextNegotiation", usePlaintextNegotiation)
         .add("useCachedDataPool", useCachedDataPool)
         .add("useBatch", useBatch)
+        .add("useGCJClient", useGCJClient)
         .toString();
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableTableAdminGCJClient.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
+import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
+import com.google.bigtable.admin.v2.GetSnapshotRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsResponse;
+import com.google.bigtable.admin.v2.Snapshot;
+import com.google.bigtable.admin.v2.SnapshotTableRequest;
+import com.google.cloud.bigtable.admin.v2.BaseBigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
+import com.google.cloud.bigtable.admin.v2.models.Table;
+import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Empty;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+
+/**
+ * This class implements existing {@link IBigtableTableAdminClient} operations with
+ * Google-cloud-java's {@link BigtableTableAdminClient} & {@link BaseBigtableTableAdminClient}.
+ */
+public class BigtableTableAdminGCJClient implements IBigtableTableAdminClient {
+
+  private final BigtableTableAdminClient delegate;
+  private final BaseBigtableTableAdminClient baseAdminClient;
+
+  public BigtableTableAdminGCJClient(@Nonnull BigtableTableAdminClient delegate,
+      @Nonnull BaseBigtableTableAdminClient baseAdminClient) {
+    this.delegate = delegate;
+    this.baseAdminClient = baseAdminClient;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Table createTable(CreateTableRequest request) {
+    return delegate.createTable(request);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Table> createTableAsync(CreateTableRequest request) {
+    return delegate.createTableAsync(request);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Table getTable(String tableId) {
+    return delegate.getTable(tableId);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Table> getTableAsync(String tableId) {
+    return delegate.getTableAsync(tableId);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public List<String> listTables() {
+    return delegate.listTables();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<List<String>> listTablesAsync() {
+    return delegate.listTablesAsync();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void deleteTable(String tableId) {
+    delegate.deleteTable(tableId);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Void> deleteTableAsync(String tableId) {
+    return delegate.deleteTableAsync(tableId);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Table modifyFamilies(ModifyColumnFamiliesRequest request) {
+    return delegate.modifyFamilies(request);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Table> modifyFamiliesAsync(ModifyColumnFamiliesRequest request) {
+    return delegate.modifyFamiliesAsync(request);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void dropRowRange(String tableId, String rowKeyPrefix) {
+    delegate.dropRowRange(tableId, rowKeyPrefix);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix) {
+    return delegate.dropRowRangeAsync(tableId, rowKeyPrefix);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void dropAllRows(String tableId) {
+    delegate.dropAllRows(tableId);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Void> dropAllRowsAsync(String tableId) {
+    return delegate.dropAllRowsAsync(tableId);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Operation> snapshotTableAsync(SnapshotTableRequest request) {
+    return baseAdminClient.snapshotTableCallable().futureCall(request);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Snapshot> getSnapshotAsync(GetSnapshotRequest request) {
+    return baseAdminClient.getSnapshotCallable().futureCall(request);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<ListSnapshotsResponse> listSnapshotsAsync(ListSnapshotsRequest request) {
+    return baseAdminClient.listSnapshotsCallable().futureCall(request);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Void> deleteSnapshotAsync(DeleteSnapshotRequest request) {
+    return ApiFutures.transform(baseAdminClient.deleteSnapshotCallable().futureCall(request),
+        new ApiFunction<Empty, Void>() {
+          @Override
+          public Void apply(Empty input) {
+            return null;
+          }
+        }, directExecutor());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Operation> createTableFromSnapshotAsync(CreateTableFromSnapshotRequest request) {
+    return baseAdminClient.createTableFromSnapshotCallable().futureCall(request);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/FakeBigtableAdminServiceImpl.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/FakeBigtableAdminServiceImpl.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc;
+
+import com.google.bigtable.admin.v2.BigtableTableAdminGrpc.BigtableTableAdminImplBase;
+import com.google.bigtable.admin.v2.ColumnFamily;
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
+import com.google.bigtable.admin.v2.CreateTableRequest;
+import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
+import com.google.bigtable.admin.v2.DeleteTableRequest;
+import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GetSnapshotRequest;
+import com.google.bigtable.admin.v2.GetTableRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsResponse;
+import com.google.bigtable.admin.v2.ListTablesRequest;
+import com.google.bigtable.admin.v2.ListTablesResponse;
+import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest;
+import com.google.bigtable.admin.v2.ModifyColumnFamiliesRequest.Modification;
+import com.google.bigtable.admin.v2.Snapshot;
+import com.google.bigtable.admin.v2.SnapshotTableRequest;
+import com.google.bigtable.admin.v2.Table;
+import com.google.cloud.bigtable.data.v2.internal.NameUtil;
+import com.google.longrunning.Operation;
+import com.google.protobuf.Empty;
+import com.google.protobuf.GeneratedMessageV3;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+
+/**
+ * Receives request generated from {@link TestBigtableTableAdminGCJClient}.
+ */
+public class FakeBigtableAdminServiceImpl extends BigtableTableAdminImplBase {
+
+  private static final BigtableInstanceName INSTANCE_NAME =
+      new BigtableInstanceName("fake-project-id", "fake-instance-id");
+  private static final String TEST_TABLE_ID_1 = "test-table-1";
+  private static final String TEST_TABLE_ID_2 = "test-table-2";
+  private static final String TEST_TABLE_ID_3 = "test-table-3";
+
+  private final LinkedBlockingQueue<GeneratedMessageV3> requests = new LinkedBlockingQueue<>();
+
+  @Override
+  public void createTable(CreateTableRequest request, StreamObserver<Table> responseObserver) {
+    responseObserver.onNext(Table.newBuilder()
+        .setName(INSTANCE_NAME.toTableNameStr(request.getTableId()))
+        .build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getTable(GetTableRequest request, StreamObserver<Table> responseObserver) {
+    String tableId = NameUtil.extractTableIdFromTableName(request.getName());
+    Table.Builder builder = Table.newBuilder()
+        .setName(INSTANCE_NAME.toTableNameStr(tableId))
+        .putColumnFamilies("first", ColumnFamily.getDefaultInstance());
+
+    if ("test-async-table".equals(tableId)) {
+      builder.putColumnFamilies("second", ColumnFamily.getDefaultInstance());
+    }
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void listTables(ListTablesRequest request,
+      StreamObserver<ListTablesResponse> responseObserver) {
+    ListTablesResponse.Builder builder = ListTablesResponse.newBuilder();
+    builder.addTablesBuilder().setName(INSTANCE_NAME.toTableNameStr(TEST_TABLE_ID_1)).build();
+    builder.addTablesBuilder().setName(INSTANCE_NAME.toTableNameStr(TEST_TABLE_ID_2)).build();
+    builder.addTablesBuilder().setName(INSTANCE_NAME.toTableNameStr(TEST_TABLE_ID_3)).build();
+    responseObserver.onNext(builder.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void deleteTable(DeleteTableRequest request, StreamObserver<Empty> responseObserver) {
+    requests.add(request);
+    responseObserver.onNext(Empty.getDefaultInstance());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void dropRowRange(DropRowRangeRequest request, StreamObserver<Empty> responseObserver) {
+    requests.add(request);
+    responseObserver.onNext(Empty.getDefaultInstance());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void createTableFromSnapshot(CreateTableFromSnapshotRequest request,
+      StreamObserver<Operation> responseObserver) {
+    responseObserver.onNext(Operation.newBuilder().setDone(true).build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void modifyColumnFamilies(ModifyColumnFamiliesRequest request,
+      StreamObserver<Table> responseObserver) {
+    Table.Builder tableBuilder = Table.newBuilder().setName(request.getName());
+    for (Modification mod : request.getModificationsList()) {
+      tableBuilder.putColumnFamilies(mod.getId(), mod.getCreate());
+    }
+    responseObserver.onNext(tableBuilder.build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void snapshotTable(SnapshotTableRequest request,
+      StreamObserver<Operation> responseObserver) {
+    responseObserver.onNext(Operation.newBuilder().setDone(true).build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getSnapshot(GetSnapshotRequest request, StreamObserver<Snapshot> responseObserver) {
+    responseObserver.onNext(Snapshot.newBuilder().setName("testSnapshotName").build());
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void listSnapshots(ListSnapshotsRequest request,
+      StreamObserver<ListSnapshotsResponse> responseObserver) {
+    ListSnapshotsResponse listSnapshot = ListSnapshotsResponse.newBuilder()
+        .addSnapshots(Snapshot.newBuilder().setName("firstSnapshotName").build())
+        .addSnapshots(Snapshot.newBuilder().setName("secondSnapshotName").build())
+        .build();
+    responseObserver.onNext(listSnapshot);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void deleteSnapshot(DeleteSnapshotRequest request,
+      StreamObserver<Empty> responseObserver) {
+    requests.add(request);
+    responseObserver.onNext(Empty.newBuilder().build());
+    responseObserver.onCompleted();
+  }
+
+  public List<GeneratedMessageV3> getRequests() {
+    return new ArrayList<>(requests);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableTableAdminGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableTableAdminGCJClient.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc;
+
+import com.google.bigtable.admin.v2.CreateTableFromSnapshotRequest;
+import com.google.bigtable.admin.v2.DeleteSnapshotRequest;
+import com.google.bigtable.admin.v2.DeleteTableRequest;
+import com.google.bigtable.admin.v2.DropRowRangeRequest;
+import com.google.bigtable.admin.v2.GetSnapshotRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsRequest;
+import com.google.bigtable.admin.v2.ListSnapshotsResponse;
+import com.google.bigtable.admin.v2.Snapshot;
+import com.google.bigtable.admin.v2.SnapshotTableRequest;
+import com.google.cloud.bigtable.admin.v2.BaseBigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.BaseBigtableTableAdminSettings;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
+import com.google.cloud.bigtable.admin.v2.models.ColumnFamily;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
+import com.google.cloud.bigtable.admin.v2.models.Table;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.BigtableVeneerSettingsFactory;
+import com.google.cloud.bigtable.config.CredentialOptions;
+import com.google.longrunning.Operation;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import java.net.ServerSocket;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Future;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnit4.class)
+public class TestBigtableTableAdminGCJClient {
+
+  private static final String PROJECT_ID = "fake-project-id";
+  private static final String INSTANCE_ID = "fake-instance-id";
+  private static final String TABLE_ID = "fake-Table-id";
+  private static final String TEST_TABLE_ID_1 = "test-table-1";
+  private static final String TEST_TABLE_ID_2 = "test-table-2";
+  private static final String TEST_TABLE_ID_3 = "test-table-3";
+  private static final String tableName =
+      NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_ID);
+
+  private Server server;
+  private BigtableTableAdminClient adminClientV2;
+  private BaseBigtableTableAdminClient baseClient;
+  private BigtableTableAdminGCJClient adminGCJClient;
+  private FakeBigtableAdminServiceImpl  serviceImpl;
+
+  @Before
+  public void setUp() throws Exception{
+    ServerSocket serverSocket = new ServerSocket(0);
+    final int availablePort = serverSocket.getLocalPort();
+    serverSocket.close();
+    BigtableOptions options = BigtableOptions.builder()
+        .setAdminHost("localhost")
+        .setPort(availablePort)
+        .setProjectId(PROJECT_ID)
+        .setInstanceId(INSTANCE_ID)
+        .setAppProfileId("AppProfileId")
+        .setUseGCJClient(true)
+        .setCredentialOptions(CredentialOptions.nullCredential())
+        .setUsePlaintextNegotiation(true)
+        .build();
+
+    serviceImpl = new FakeBigtableAdminServiceImpl();
+    server = ServerBuilder.forPort(availablePort).addService(serviceImpl).build();
+    server.start();
+    BigtableTableAdminSettings settings =
+        BigtableVeneerSettingsFactory.createTableAdminSettings(options);
+    adminClientV2 = BigtableTableAdminClient.create(settings);
+    BaseBigtableTableAdminSettings baseSettings =
+        BaseBigtableTableAdminSettings.create(settings.getStubSettings());
+    baseClient = BaseBigtableTableAdminClient.create(baseSettings);
+    adminGCJClient = new BigtableTableAdminGCJClient(adminClientV2, baseClient);
+  }
+
+  @Test
+  public void testCreateTable(){
+    CreateTableRequest req = CreateTableRequest.of(TABLE_ID);
+    Table response = adminGCJClient.createTable(req);
+    assertEquals(TABLE_ID, response.getId());
+  }
+
+  @Test
+  public void testCreateTableAsync() throws Exception {
+    CreateTableRequest req = CreateTableRequest.of(TABLE_ID);
+    Future<Table> response = adminGCJClient.createTableAsync(req);
+    assertEquals(TABLE_ID, response.get().getId());
+  }
+
+  @Test
+  public void testGetTable() {
+    Table response = adminGCJClient.getTable(TABLE_ID);
+    assertEquals(1, response.getColumnFamilies().size());
+  }
+
+  @Test
+  public void testGetTableAsync() throws Exception {
+    Future<Table> response = adminGCJClient.getTableAsync("test-async-table");
+    assertEquals(2, response.get().getColumnFamilies().size());
+  }
+
+  @Test
+  public void testListTables() {
+    List<String> tableIds = adminGCJClient.listTables();
+    assertEquals(Arrays.asList(TEST_TABLE_ID_1, TEST_TABLE_ID_2, TEST_TABLE_ID_3), tableIds);
+  }
+
+  @Test
+  public void testListTablesAsync() throws Exception {
+    Future<List<String>> tableIds = adminGCJClient.listTablesAsync();
+    assertEquals(Arrays.asList(TEST_TABLE_ID_1, TEST_TABLE_ID_2,
+        TEST_TABLE_ID_3), tableIds.get());
+  }
+
+  @Test
+  public void testDeleteTable(){
+    adminGCJClient.deleteTable("deleteTableID");
+    DeleteTableRequest deleteTableReq = (DeleteTableRequest) serviceImpl.getRequests().get(0);
+    assertEquals("deleteTableID", NameUtil.extractTableIdFromTableName(deleteTableReq.getName()));
+  }
+
+  @Test
+  public void testDeleteTableAsync() throws Exception {
+    Future<Void> deleteResponse =  adminGCJClient.deleteTableAsync("deleteAsyncTableID");
+    deleteResponse.get();
+    DeleteTableRequest deleteTableReq = (DeleteTableRequest) serviceImpl.getRequests().get(0);
+    assertEquals("deleteAsyncTableID", NameUtil.extractTableIdFromTableName(deleteTableReq.getName()));
+  }
+
+  @Test
+  public void testModifyFamily(){
+    ModifyColumnFamiliesRequest request = ModifyColumnFamiliesRequest.of(TABLE_ID)
+        .addFamily("first-family");
+    Table response = adminGCJClient.modifyFamilies(request);
+    List<ColumnFamily> columnFamilies = response.getColumnFamilies();
+    assertEquals("first-family", columnFamilies.get(0).getId());
+  }
+
+  @Test
+  public void testModifyFamilyAsync() throws Exception{
+    ModifyColumnFamiliesRequest request = ModifyColumnFamiliesRequest.of(TABLE_ID)
+        .addFamily("first-family")
+        .addFamily("another-family");
+    Future<Table> response = adminGCJClient.modifyFamiliesAsync(request);
+    List<ColumnFamily> columnFamilies = response.get().getColumnFamilies();
+    assertEquals("first-family", columnFamilies.get(0).getId());
+    assertEquals("another-family", columnFamilies.get(1).getId());
+  }
+
+  @Test
+  public void dropRowRange(){
+    String rowKey = "cf-dropRange";
+    adminGCJClient.dropRowRange(TABLE_ID, rowKey);
+    DropRowRangeRequest rangeRequest = (DropRowRangeRequest) serviceImpl.getRequests().get(0);
+    assertEquals(TABLE_ID, NameUtil.extractTableIdFromTableName(rangeRequest.getName()));
+    assertEquals(rowKey, rangeRequest.getRowKeyPrefix().toStringUtf8());
+  }
+
+  @Test
+  public void dropRowRangeAsync() throws Exception{
+    String rowKey = "cf-dropRange-async";
+    adminGCJClient.dropRowRangeAsync(TABLE_ID, rowKey).get();
+    DropRowRangeRequest rangeRequest = (DropRowRangeRequest) serviceImpl.getRequests().get(0);
+    assertEquals(TABLE_ID, NameUtil.extractTableIdFromTableName(rangeRequest.getName()));
+    assertEquals(rowKey, rangeRequest.getRowKeyPrefix().toStringUtf8());
+  }
+
+  @Test
+  public void dropAllRows(){
+    String tableId = "tableWithNoDataId";
+    adminGCJClient.dropAllRows(tableId);
+    DropRowRangeRequest rangeRequest = (DropRowRangeRequest) serviceImpl.getRequests().get(0);
+    assertEquals(tableId, NameUtil.extractTableIdFromTableName(rangeRequest.getName()));
+  }
+
+  @Test
+  public void dropAllRowsAsync() throws Exception{
+    String tableId = "tableWithNoDataId";
+    adminGCJClient.dropAllRowsAsync(tableId).get();
+    DropRowRangeRequest rangeRequest = (DropRowRangeRequest) serviceImpl.getRequests().get(0);
+    assertEquals(tableId, NameUtil.extractTableIdFromTableName(rangeRequest.getName()));
+  }
+
+  @Test
+  public void testSnapshotTableAsync() throws Exception {
+    SnapshotTableRequest request = SnapshotTableRequest.newBuilder()
+        .setSnapshotId("snapshotId")
+        .setName(tableName)
+        .build();
+    Future<Operation> actualResponse = adminGCJClient.snapshotTableAsync(request);
+    assertTrue(actualResponse.get().getDone());
+  }
+
+  @Test
+  public void testGetSnapshotAsync() throws Exception {
+    GetSnapshotRequest request = GetSnapshotRequest.newBuilder()
+        .setName(tableName)
+        .build();
+    Future<Snapshot> actualResponse = adminGCJClient.getSnapshotAsync(request);
+    assertEquals("testSnapshotName", actualResponse.get().getName());
+  }
+
+  @Test
+  public void testListSnapshotsAsync() throws Exception {
+    ListSnapshotsRequest request = ListSnapshotsRequest.newBuilder()
+        .setParent(tableName)
+        .build();
+    Future<ListSnapshotsResponse> actualResponse = adminGCJClient.listSnapshotsAsync(request);
+    assertEquals("firstSnapshotName",
+        actualResponse.get().getSnapshots(0).getName());
+    assertEquals("secondSnapshotName",
+        actualResponse.get().getSnapshots(1).getName());
+  }
+
+  @Test
+  public void testDeleteSnapshotAsync() throws Exception{
+    DeleteSnapshotRequest request = DeleteSnapshotRequest.newBuilder()
+        .setName("testSnapshotName")
+        .build();
+    adminGCJClient.deleteSnapshotAsync(request).get();
+    DeleteSnapshotRequest receivedReq = (DeleteSnapshotRequest) serviceImpl.getRequests().get(0);
+    assertEquals("testSnapshotName", receivedReq.getName());
+  }
+
+  @Test
+  public void testCreateTableFromSnapshotAsync() throws Exception {
+    CreateTableFromSnapshotRequest request = CreateTableFromSnapshotRequest.newBuilder()
+        .setTableId(TABLE_ID)
+        .setSourceSnapshot("test-snapshot")
+        .build();
+    Future<Operation> actualResponse = adminGCJClient.createTableFromSnapshotAsync(request);
+    assertTrue(actualResponse.get().getDone());
+  }
+
+  @After
+  public void tearDown() throws Exception{
+    if(adminClientV2 != null){
+      adminClientV2.close();
+      adminClientV2 = null;
+    }
+    if(baseClient != null){
+      baseClient.close();
+      baseClient = null;
+    }
+    if(server != null){
+      server.shutdown();
+      server.awaitTermination();
+      server = null;
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/test_env/BigtableEnv.java
@@ -54,7 +54,8 @@ class BigtableEnv extends SharedTestEnv {
       "google.bigtable.instance.id",
       "google.bigtable.use.bulk.api",
       "google.bigtable.use.plaintext.negotiation",
-      "google.bigtable.snapshot.cluster.id"
+      "google.bigtable.snapshot.cluster.id",
+      "google.bigtable.use.gcj.client"
   );
 
   @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -281,6 +281,9 @@ public class BigtableOptionsFactory {
    */
   public static final String BIGTABLE_NAMESPACE_WARNING_KEY = "google.bigtable.namespace.warnings";
 
+  /** A flag to decide which implementation to use for data & admin operation */
+  public static final String BIGTABLE_USE_GCJ_CLIENT = "google.bigtable.use.gcj.client";
+
   /**
    * <p>fromConfiguration.</p>
    *
@@ -322,6 +325,9 @@ public class BigtableOptionsFactory {
     }
     bigtableOptionsBuilder.setUseBatch(configuration.getBoolean(BIGTABLE_USE_BATCH, false));
 
+    //TODO(rahulkql): verify presence of this env varible.
+    bigtableOptionsBuilder.setUseGCJClient(configuration.getBoolean(BIGTABLE_USE_GCJ_CLIENT,
+        false));
     return bigtableOptionsBuilder.build();
   }
 


### PR DESCRIPTION
Replace all occurence of `IBigtableTableAdminClient` `BigtableTableAdminClient` & `BaseBigtableTableAdminClient`.
Also updated all of snapshotOperation to utilize `BaseBigtableTableAdminClient`.