### PR TITLE
Refactored readModifyWrite from BulkMutation

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -28,12 +28,12 @@ import com.google.common.util.concurrent.ListenableFuture;
 public interface IBulkMutation {
 
   /**
-   * Send any outstanding {@link RowMutation} and wait until all requests are complete.
+   * Sends any outstanding {@link RowMutation} and wait until all requests are complete.
    */
   void flush() throws InterruptedException;
 
   /**
-   * Send any outstanding {@link RowMutation}s, present in the current batch.
+   * Sends any outstanding {@link RowMutation}s, present in the current batch.
    */
   void sendUnsent();
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -16,11 +16,7 @@
 package com.google.cloud.bigtable.core;
 
 import com.google.api.core.ApiFuture;
-import com.google.bigtable.v2.MutateRowRequest;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
-
-import com.google.cloud.bigtable.grpc.async.OperationAccountant;
-import com.google.common.util.concurrent.ListenableFuture;
 
 /**
  * Interface to support batching multiple RowMutation request into a single grpc request.
@@ -50,12 +46,4 @@ public interface IBulkMutation {
    * successful otherwise exception will be thrown.
    */
   ApiFuture<Void> add(RowMutation rowMutation);
-
-  /**
-   * Adds a future task as RPC operation. This method may block if
-   * {@link OperationAccountant#registerOperation(ListenableFuture)} blocks.
-   *
-   * @param future a {@link ApiFuture} which would be listened for completion events.
-   */
-  void register(final ApiFuture<?> future);
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -16,8 +16,6 @@
 package com.google.cloud.bigtable.core;
 
 import com.google.api.core.ApiFuture;
-import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
-import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 
 import com.google.cloud.bigtable.grpc.async.OperationAccountant;
@@ -33,6 +31,9 @@ public interface IBulkMutation {
    */
   void flush() throws InterruptedException;
 
+  /**
+   * Runs unfinished task. This method blocks until accumulated tasks are finished.
+   */
   void sendUnsent();
 
   /**
@@ -50,12 +51,10 @@ public interface IBulkMutation {
   ApiFuture<Void> add(RowMutation rowMutation);
 
   /**
-   * Performs a {@link IBigtableDataClient#readModifyWriteRowAsync(ReadModifyWriteRow)} on the
-   * {@link ReadModifyWriteRow}. This method may block if
+   * Adds a future task as RPC operation. This method may block if
    * {@link OperationAccountant#registerOperation(ListenableFuture)} blocks.
    *
-   * @param request The {@link ReadModifyWriteRow} to send.
-   * @return a {@link ApiFuture} which can be listened to for completion events.
+   * @param future a {@link ApiFuture} which would be listened for completion events.
    */
-  ApiFuture<Row> readModifyWrite(ReadModifyWriteRow request);
+  void register(final ApiFuture<?> future);
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.core;
 
 import com.google.api.core.ApiFuture;
+import com.google.bigtable.v2.MutateRowRequest;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 
 import com.google.cloud.bigtable.grpc.async.OperationAccountant;
@@ -32,7 +33,7 @@ public interface IBulkMutation {
   void flush() throws InterruptedException;
 
   /**
-   * Runs unfinished task. This method blocks until accumulated tasks are finished.
+   * Send any outstanding {@link RowMutation}s, present in the current batch.
    */
   void sendUnsent();
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -364,7 +364,6 @@ public class BigtableSession implements Closeable {
     return new BulkMutation(
         tableName,
         throttlingDataClient,
-        new BigtableDataClientWrapper(throttlingDataClient, getDataRequestContext()),
         BigtableSessionSharedThreadPools.getInstance().getRetryExecutor(),
         options.getBulkOptions());
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -16,7 +16,6 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
-import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.api.client.util.NanoClock;
 import com.google.bigtable.v2.MutateRowRequest;
@@ -445,17 +444,6 @@ public class BulkMutation {
     }
 
     return future;
-  }
-
-  /**
-   * Adds a future task as RPC operation. This method may block if
-   * {@link OperationAccountant#registerOperation(ListenableFuture)} blocks.
-   *
-   * @param future a {@link ListenableFuture} which would be listened for completion events.
-   */
-  @InternalApi("This is public only for technical reasons")
-  public void register(ListenableFuture<?> future) {
-    operationAccountant.registerOperation(future);
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutation.java
@@ -16,9 +16,7 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
-import com.google.cloud.bigtable.core.IBigtableDataClient;
-import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
-import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.api.client.util.NanoClock;
 import com.google.bigtable.v2.MutateRowRequest;
@@ -32,7 +30,6 @@ import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
 import com.google.cloud.bigtable.metrics.Meter;
-import com.google.cloud.bigtable.util.ApiFutureUtil;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.FutureCallback;
@@ -343,7 +340,6 @@ public class BulkMutation {
 
   private final String tableName;
   private final BigtableDataClient client;
-  private final IBigtableDataClient clientWrapper;
   private final OperationAccountant operationAccountant;
   private final ScheduledExecutorService retryExecutorService;
   private final int maxRowKeyCount;
@@ -361,8 +357,6 @@ public class BulkMutation {
    *          {@link MutateRowRequest}s will be sent.
    * @param client a {@link BigtableDataClient} object on which to perform RPCs.
    *          RPCs that this object performed.
-   * @param clientWrapper a {@link IBigtableDataClient} object on which to perform RPCs.
-   *          RPCs that this object performed.
    * @param retryExecutorService a {@link ScheduledExecutorService} object on which to schedule
    *          retries.
    * @param bulkOptions a {@link BulkOptions} with the user specified options for the behavior of
@@ -371,22 +365,19 @@ public class BulkMutation {
   public BulkMutation(
       BigtableTableName tableName,
       BigtableDataClient client,
-      IBigtableDataClient clientWrapper,
       ScheduledExecutorService retryExecutorService,
       BulkOptions bulkOptions) {
-    this(tableName, client, clientWrapper, new OperationAccountant(), retryExecutorService, bulkOptions);
+    this(tableName, client, new OperationAccountant(), retryExecutorService, bulkOptions);
   }
 
   BulkMutation(
       BigtableTableName tableName,
       BigtableDataClient client,
-      IBigtableDataClient clientWrapper,
       OperationAccountant operationAccountant,
       ScheduledExecutorService retryExecutorService,
       BulkOptions bulkOptions) {
     this.tableName = tableName.toString();
     this.client = client;
-    this.clientWrapper = clientWrapper;
     this.retryExecutorService = retryExecutorService;
     this.operationAccountant = operationAccountant;
     this.maxRowKeyCount = bulkOptions.getBulkMaxRowKeyCount();
@@ -456,26 +447,15 @@ public class BulkMutation {
     return future;
   }
 
-
   /**
-   * Performs a {@link IBigtableDataClient#readModifyWriteRowAsync(ReadModifyWriteRow)} on the
-   * {@link ReadModifyWriteRow}. This method may block if
+   * Adds a future task as RPC operation. This method may block if
    * {@link OperationAccountant#registerOperation(ListenableFuture)} blocks.
    *
-   * @param request The {@link ReadModifyWriteRow} to send.
-   * @return a {@link com.google.common.util.concurrent.ListenableFuture} which can be listened to for completion events.
+   * @param future a {@link ListenableFuture} which would be listened for completion events.
    */
-  public ListenableFuture<Row> readModifyWrite(ReadModifyWriteRow request) {
-    // Wait until both the memory and rpc count maximum requirements are achieved before getting a
-    // unique id used to track this request.
-    ListenableFuture<Row> future;
-    try {
-      future = ApiFutureUtil.adapt(clientWrapper.readModifyWriteRowAsync(request));
-    } catch (Throwable e) {
-      future = Futures.immediateFailedFuture(e);
-    }
+  @InternalApi("This is public only for technical reasons")
+  public void register(ListenableFuture<?> future) {
     operationAccountant.registerOperation(future);
-    return future;
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
@@ -66,10 +66,4 @@ public class BulkMutationWrapper implements IBulkMutation {
           }
         });
   }
-
-  /** {@inheritDoc} */
-  @Override
-  public void register(ApiFuture<?> future) {
-    delegate.register(ApiFutureUtil.adapt(future));
-  }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
@@ -19,8 +19,6 @@ import com.google.api.core.ApiFuture;
 import com.google.bigtable.v2.MutateRowResponse;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
-import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
-import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.cloud.bigtable.util.ApiFutureUtil;
 import com.google.common.base.Function;
@@ -71,7 +69,7 @@ public class BulkMutationWrapper implements IBulkMutation {
 
   /** {@inheritDoc} */
   @Override
-  public ApiFuture<Row> readModifyWrite(ReadModifyWriteRow request) {
-    return ApiFutureUtil.adapt(delegate.readModifyWrite(request));
+  public void register(ApiFuture<?> future) {
+    delegate.register(ApiFutureUtil.adapt(future));
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
@@ -29,10 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.google.api.core.SettableApiFuture;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
-import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
-import com.google.cloud.bigtable.data.v2.models.Row;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -294,7 +291,7 @@ public class TestBulkMutation {
   public void testAutoflush() throws Exception {
     // Setup a BulkMutation with autoflush enabled: the scheduled flusher will get captured by the
     // scheduled executor mock
-    underTest = new BulkMutation(TABLE_NAME, client, clientWrapper, operationAccountant,
+    underTest = new BulkMutation(TABLE_NAME, client, operationAccountant,
         retryExecutorService, BulkOptions.builder().setAutoflushMs(1000L).build());
     ArgumentCaptor<Runnable> autoflusher = ArgumentCaptor.forClass(Runnable.class);
     when(retryExecutorService.schedule(autoflusher.capture(), anyLong(), any(TimeUnit.class)))
@@ -376,23 +373,14 @@ public class TestBulkMutation {
 
   @Test
   public void testReadWriteModify()  {
-    SettableApiFuture<Row> future = SettableApiFuture.create();
-    when(clientWrapper.readModifyWriteRowAsync(any(ReadModifyWriteRow.class))).thenReturn(future);
-    underTest.readModifyWrite(ReadModifyWriteRow.create("table", "key"));
+    underTest.register(future);
     Assert.assertTrue(operationAccountant.hasInflightOperations());
     future.set(null);
     Assert.assertFalse(operationAccountant.hasInflightOperations());
   }
 
-  @Test
-  public void testInvalidMutation() {
-    when(clientWrapper.readModifyWriteRowAsync(any(ReadModifyWriteRow.class))).thenThrow(new RuntimeException());
-    underTest.readModifyWrite(ReadModifyWriteRow.create("table", "key"));
-    Assert.assertFalse(operationAccountant.hasInflightOperations());
-  }
-
   private BulkMutation createBulkMutation() {
-    return new BulkMutation(TABLE_NAME, client, clientWrapper, operationAccountant,
+    return new BulkMutation(TABLE_NAME, client, operationAccountant,
         retryExecutorService, BULK_OPTIONS);
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutation.java
@@ -371,14 +371,6 @@ public class TestBulkMutation {
     underTest.add(bigRequest.build());
   }
 
-  @Test
-  public void testReadWriteModify()  {
-    underTest.register(future);
-    Assert.assertTrue(operationAccountant.hasInflightOperations());
-    future.set(null);
-    Assert.assertFalse(operationAccountant.hasInflightOperations());
-  }
-
   private BulkMutation createBulkMutation() {
     return new BulkMutation(TABLE_NAME, client, operationAccountant,
         retryExecutorService, BULK_OPTIONS);

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationAwaitCompletion.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationAwaitCompletion.java
@@ -300,7 +300,6 @@ public class TestBulkMutationAwaitCompletion {
         new BulkMutation(
             TestBulkMutation.TABLE_NAME,
             mockClient,
-            mockClientWrapper,
             operationAccountant,
             mockScheduler,
             options);
@@ -327,7 +326,7 @@ public class TestBulkMutationAwaitCompletion {
 
   /**
    * Checks to make sure that for all accountants that
-   * !{@link AsyncExecutor#hasInflightRequests()} and that for all futures that
+   * !{@link OperationAccountant#hasInflightOperations()} and that for all futures that
    * {@link Future#isDone()}.
    */
   protected void confirmCompletion() {

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
@@ -15,19 +15,14 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import com.google.api.core.SettableApiFuture;
 import com.google.bigtable.v2.MutateRowResponse;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
-import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
-import com.google.cloud.bigtable.data.v2.models.Row;
-import com.google.cloud.bigtable.data.v2.models.RowCell;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.protobuf.ByteString;
-import java.util.Collections;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.junit.Before;
 import org.junit.Test;
@@ -35,8 +30,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -91,13 +86,11 @@ import static org.mockito.Mockito.when;
   }
 
   @Test
-  public void testReadModifyRow() throws InterruptedException, ExecutionException {
-    ReadModifyWriteRow readModifyRow = ReadModifyWriteRow.create("tableId", "test-key");
-    ListenableFuture<Row> expectedResponse = Futures.immediateFuture(
-        Row.create(ByteString.copyFromUtf8("test-key"), Collections.<RowCell>emptyList()));
-    when(mockDelegate.readModifyWrite(readModifyRow)).thenReturn(expectedResponse);
-    Future<Row> actualResponse = bulkWrapper.readModifyWrite(readModifyRow);
-    assertEquals(expectedResponse.get(), actualResponse.get());
-    verify(mockDelegate).readModifyWrite(readModifyRow);
+  public void testRegister(){
+    SettableApiFuture<Void> future = SettableApiFuture.create();
+    future.set(null);
+    doNothing().when(mockDelegate).register(any(ListenableFuture.class));
+    bulkWrapper.register(future);
+    verify(mockDelegate).register(any(ListenableFuture.class));
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
@@ -15,14 +15,12 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
-import com.google.api.core.SettableApiFuture;
 import com.google.bigtable.v2.MutateRowResponse;
 import com.google.bigtable.v2.MutateRowsRequest;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import java.util.concurrent.Future;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,7 +29,6 @@ import org.junit.runners.JUnit4;
 import org.mockito.Mockito;
 
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -83,14 +80,5 @@ import static org.mockito.Mockito.when;
       throw new AssertionError("Assertion failed for BulkMutationWrapper#add(RowMutation)");
     }
     verify(mockDelegate).add(requestProto);
-  }
-
-  @Test
-  public void testRegister(){
-    SettableApiFuture<Void> future = SettableApiFuture.create();
-    future.set(null);
-    doNothing().when(mockDelegate).register(any(ListenableFuture.class));
-    bulkWrapper.register(future);
-    verify(mockDelegate).register(any(ListenableFuture.class));
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -17,8 +17,8 @@ package com.google.cloud.bigtable.hbase;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBulkMutation;
-import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -65,8 +65,8 @@ public class BigtableBufferedMutatorHelper {
 
   private final HBaseRequestAdapter adapter;
   private final IBulkMutation bulkMutation;
+  private final IBigtableDataClient dataClient;
   private final BigtableOptions options;
-  private final RequestContext requestContext;
 
   /**
    * <p>
@@ -85,7 +85,7 @@ public class BigtableBufferedMutatorHelper {
     this.options = session.getOptions();
     BigtableTableName tableName = this.adapter.getBigtableTableName();
     this.bulkMutation = session.createBulkMutationWrapper(tableName);
-    this.requestContext = session.getDataRequestContext();
+    this.dataClient = session.getClientWrapper();
   }
 
   public void close() throws IOException {
@@ -200,9 +200,11 @@ public class BigtableBufferedMutatorHelper {
       } else if (mutation instanceof Delete) {
         future = bulkMutation.add(adapter.adaptEntry((Delete) mutation));
       } else if (mutation instanceof Increment) {
-        future = bulkMutation.readModifyWrite(adapter.adapt((Increment) mutation));
+        future = dataClient.readModifyWriteRowAsync(adapter.adapt((Increment) mutation));
+        bulkMutation.register(future);
       } else if (mutation instanceof Append) {
-        future = bulkMutation.readModifyWrite(adapter.adapt((Append) mutation));
+        future = dataClient.readModifyWriteRowAsync(adapter.adapt((Append) mutation));
+        bulkMutation.register(future);
       } else {
         future = ApiFutures.immediateFailedFuture(new IllegalArgumentException(
             "Encountered unknown mutation type: " + mutation.getClass()));

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -124,6 +125,9 @@ public class TestBatchExecutor {
   private IBulkMutation mockBulkMutation;
 
   @Mock
+  private IBigtableDataClient mockDataClient;
+
+  @Mock
   private ApiFuture mockFuture;
 
   private HBaseRequestAdapter requestAdapter;
@@ -143,7 +147,8 @@ public class TestBatchExecutor {
 
     MockitoAnnotations.initMocks(this);
     when(mockBulkMutation.add(any(RowMutation.class))).thenReturn(mockFuture);
-    when(mockBulkMutation.readModifyWrite(any(ReadModifyWriteRow.class))).thenReturn(mockFuture);
+    when(mockBigtableSession.getClientWrapper()).thenReturn(mockDataClient);
+    when(mockDataClient.readModifyWriteRowAsync(any(ReadModifyWriteRow.class))).thenReturn(mockFuture);
     when(mockBigtableSession.getDataRequestContext()).thenReturn(requetsContext);
     when(mockBigtableSession.createBulkMutationWrapper(any(BigtableTableName.class))).thenReturn(mockBulkMutation);
     when(mockBigtableSession.createBulkRead(any(BigtableTableName.class))).thenReturn(mockBulkRead);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
+import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import java.io.IOException;
@@ -70,6 +71,9 @@ public class TestBigtableBufferedMutator {
   @Mock
   private IBulkMutation mockBulkMutation;
 
+  @Mock
+  private IBigtableDataClient mockDataClient;
+
   @SuppressWarnings("rawtypes")
   private SettableApiFuture future = SettableApiFuture.create();
 
@@ -83,6 +87,7 @@ public class TestBigtableBufferedMutator {
     MockitoAnnotations.initMocks(this);
     when(mockSession.createBulkMutationWrapper(any(BigtableTableName.class))).thenReturn(mockBulkMutation);
     when(mockSession.getDataRequestContext()).thenReturn(RequestContext.create("p", "i", "a"));
+    when(mockSession.getClientWrapper()).thenReturn(mockDataClient);
   }
 
   @After
@@ -124,22 +129,22 @@ public class TestBigtableBufferedMutator {
 
   @Test
   public void testIncrement() throws IOException {
-    when(mockBulkMutation.readModifyWrite(any(ReadModifyWriteRow.class)))
+    when(mockDataClient.readModifyWriteRowAsync(any(ReadModifyWriteRow.class)))
         .thenReturn(future);
     BigtableBufferedMutator underTest = createMutator(new Configuration(false));
     underTest.mutate(new Increment(EMPTY_BYTES).addColumn(EMPTY_BYTES, EMPTY_BYTES, 1));
-    verify(mockBulkMutation, times(1))
-        .readModifyWrite(any(ReadModifyWriteRow.class));
+    verify(mockDataClient, times(1))
+        .readModifyWriteRowAsync(any(ReadModifyWriteRow.class));
   }
 
   @Test
   public void testAppend() throws IOException {
-    when(mockBulkMutation.readModifyWrite(any(ReadModifyWriteRow.class)))
+    when(mockDataClient.readModifyWriteRowAsync(any(ReadModifyWriteRow.class)))
         .thenReturn(future);
     BigtableBufferedMutator underTest = createMutator(new Configuration(false));
     underTest.mutate(new Append(EMPTY_BYTES).add(EMPTY_BYTES, EMPTY_BYTES, EMPTY_BYTES));
-    verify(mockBulkMutation, times(1))
-        .readModifyWrite(any(ReadModifyWriteRow.class));
+    verify(mockDataClient, times(1))
+        .readModifyWriteRowAsync(any(ReadModifyWriteRow.class));
   }
 
   @Test


### PR DESCRIPTION
- Refactored `#readModifyWrite` from `BulkMutation` & `IBulkMutation`.
- Added `BulkMutation#register` to be able to add future tasks in the ongoing batch.
- Refactored `BigtableBufferedMutatorHelper` to add `IBigtableDataClient` to and redirected readModifyWrite call.
- refactored unit test cases.