### PR TITLE
Removing shutdown hook from AbstractBigtableConnection

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBulkMutation.java
@@ -41,9 +41,6 @@ public interface IBulkMutation extends AutoCloseable {
   /** Sends any outstanding {@link RowMutation} and wait until all requests are complete. */
   void flush() throws InterruptedException;
 
-  /** @return false if there is any outstanding {@link RowMutation} that still needs to be sent. */
-  boolean isFlushed();
-
   /** Closes this bulk Mutation and prevents from mutating any more elements */
   @Override
   void close() throws IOException;

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
@@ -69,12 +69,6 @@ public class BulkMutationGCJClient implements IBulkMutation {
     }
   }
 
-  /** {@inheritDoc} */
-  @Override
-  public boolean isFlushed() {
-    return !operationAccountant.hasInflightOperations();
-  }
-
   @Override
   public void close() throws IOException {
     try {

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationWrapper.java
@@ -63,12 +63,6 @@ public class BulkMutationWrapper implements IBulkMutation {
     delegate.flush();
   }
 
-  /** {@inheritDoc} */
-  @Override
-  public boolean isFlushed() {
-    return delegate.isFlushed();
-  }
-
   @Override
   public void close() throws IOException {
     isClosed = true;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
@@ -110,16 +110,6 @@ public class TestBulkMutationGCJClient {
   }
 
   @Test
-  public void testIsFlushed() {
-    when(callable.futureCall(rowMutation)).thenReturn(future);
-    bulkMutationClient.add(rowMutation);
-    assertFalse("BulkMutation should have one pending element", bulkMutationClient.isFlushed());
-    future.set(null);
-    assertTrue("BulkMutation should not have any pending element", bulkMutationClient.isFlushed());
-    verify(callable).futureCall(rowMutation);
-  }
-
-  @Test
   public void testIsClosed() throws IOException {
     bulkMutationClient.close();
     Exception actualEx = null;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationWrapper.java
@@ -64,13 +64,6 @@ public class TestBulkMutationWrapper {
   }
 
   @Test
-  public void testIsFlushed() {
-    when(mockDelegate.isFlushed()).thenReturn(true);
-    assertTrue(bulkWrapper.isFlushed());
-    verify(mockDelegate).isFlushed();
-  }
-
-  @Test
   public void testAddMutate() {
     RowMutation rowMutation = RowMutation.create("tableId", "key");
     MutateRowsRequest.Entry requestProto = rowMutation.toBulkProto(requestContext).getEntries(0);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -149,15 +149,6 @@ public class BigtableBufferedMutator implements BufferedMutator {
   }
 
   /**
-   * hasInflightRequests.
-   *
-   * @return a boolean.
-   */
-  public boolean hasInflightRequests() {
-    return helper.hasInflightRequests();
-  }
-
-  /**
    * Create a {@link RetriesExhaustedWithDetailsException} if there were any async exceptions and
    * send it to the {@link org.apache.hadoop.hbase.client.BufferedMutator.ExceptionListener}.
    */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -223,15 +223,4 @@ public class BigtableBufferedMutatorHelper {
     }
     return future;
   }
-
-  /**
-   * hasInflightRequests.
-   *
-   * @return a boolean.
-   */
-  public boolean hasInflightRequests() {
-    return bulkMutation != null
-        && !bulkMutation.isFlushed()
-        && operationAccountant.hasInflightOperations();
-  }
 }


### PR DESCRIPTION
This change will remove IBulkMutation#isFlushed to keep the batching interface similar to core Batching API(gax's Batcher).

Note: **This PR will not affect HBase client behavior**. As the above-mentioned method was only used for printing log warnings in case some of the mutations(read rows/mutate) are not finished before triggering connection shutdown.