### PR TITLE
test: updates snapshot operation with sanitary checks

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
@@ -20,6 +20,7 @@ import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -222,6 +223,7 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
       actualError = ex;
     }
     assertNotNull(actualError);
+    assertTrue(actualError instanceof NullPointerException);
     actualError = null;
 
     try {
@@ -250,6 +252,7 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
       actualError = ex;
     }
     assertNotNull(actualError);
+    assertTrue(actualError instanceof NullPointerException);
     actualError = null;
 
     try {

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
@@ -215,7 +215,7 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
   }
 
   @Test
-  public void testListSnapshotsWithNullAndEmptyString() {
+  public void testListSnapshotsWithNullAndEmptyString() throws IOException {
     Exception actualError = null;
     try {
       listSnapshotsSize((String) null);
@@ -224,26 +224,14 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
     }
     assertNotNull(actualError);
     assertTrue(actualError instanceof NullPointerException);
-    actualError = null;
 
-    try {
-      assertEquals(0, listSnapshotsSize((Pattern) null));
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
-    actualError = null;
+    assertEquals(0, listSnapshotsSize((Pattern) null));
 
-    try {
-      assertEquals(0, listSnapshotsSize(""));
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
+    assertEquals(0, listSnapshotsSize(""));
   }
 
   @Test
-  public void testListTableSnapshotsWithNullAndEmptyString() {
+  public void testListTableSnapshotsWithNullAndEmptyString() throws IOException {
     Exception actualError = null;
     try {
       listTableSnapshotsSize(null, "");
@@ -253,53 +241,23 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
     }
     assertNotNull(actualError);
     assertTrue(actualError instanceof NullPointerException);
-    actualError = null;
 
-    try {
-      assertEquals(0, listTableSnapshotsSize((Pattern) null, null));
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
+    assertEquals(0, listTableSnapshotsSize((Pattern) null, null));
 
-    try {
-      assertEquals(0, listTableSnapshotsSize("", ""));
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
+    assertEquals(0, listTableSnapshotsSize("", ""));
   }
 
   @Test
   public void testDeleteSnapshotWithEmptyString() throws Exception {
+    // No snapshot matches hence no exception should be thrown
     Exception actualError = null;
     try {
-      // No snapshot should match and no exception should throw
       deleteSnapshots(null);
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
 
-    try {
-      // No snapshot should match and no exception should throw
       deleteSnapshots(Pattern.compile(""));
-    } catch (Exception ex) {
-      // H2 No Error
-      actualError = ex;
-    }
-    assertNull(actualError);
 
-    try {
-      // No snapshot should match and no exception should throw
       deleteTableSnapshots(null, null);
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
 
-    try {
-      // No snapshot should match and no exception should throw
       deleteTableSnapshots(Pattern.compile(""), Pattern.compile(""));
     } catch (Exception ex) {
       actualError = ex;

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
@@ -19,7 +19,6 @@ package com.google.cloud.bigtable.hbase;
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -249,20 +248,14 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
 
   @Test
   public void testDeleteSnapshotWithEmptyString() throws Exception {
-    // No snapshot matches hence no exception should be thrown
-    Exception actualError = null;
-    try {
-      deleteSnapshots(null);
+    // No snapshot matches with null or empty string hence no exception should be thrown
+    deleteSnapshots(null);
 
-      deleteSnapshots(Pattern.compile(""));
+    deleteSnapshots(Pattern.compile(""));
 
-      deleteTableSnapshots(null, null);
+    deleteTableSnapshots(null, null);
 
-      deleteTableSnapshots(Pattern.compile(""), Pattern.compile(""));
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
+    deleteTableSnapshots(Pattern.compile(""), Pattern.compile(""));
   }
 
   private void checkSnapshotCount(Admin admin, int count) throws IOException {

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestSnapshot.java
@@ -17,6 +17,9 @@
 package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -190,6 +193,117 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
     Assert.assertEquals(1, listTableSnapshotsSize(Pattern.compile(tableName.getNameAsString())));
   }
 
+  @Test
+  public void testSnapshotTableWithNullAndEmptyString() {
+    Exception actualError = null;
+    try {
+      snapshot("test-snapshot", null);
+      Assert.fail("listTableSnapshots with null tableName should fail");
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      snapshot(null, tableName);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+  }
+
+  @Test
+  public void testListSnapshotsWithNullAndEmptyString() {
+    Exception actualError = null;
+    try {
+      listSnapshotsSize((String) null);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      assertEquals(0, listSnapshotsSize((Pattern) null));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+    actualError = null;
+
+    try {
+      assertEquals(0, listSnapshotsSize(""));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+  }
+
+  @Test
+  public void testListTableSnapshotsWithNullAndEmptyString() {
+    Exception actualError = null;
+    try {
+      listTableSnapshotsSize(null, "");
+      Assert.fail("listTableSnapshots with null tableName should fail");
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      assertEquals(0, listTableSnapshotsSize((Pattern) null, null));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+
+    try {
+      assertEquals(0, listTableSnapshotsSize("", ""));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+  }
+
+  @Test
+  public void testDeleteSnapshotWithEmptyString() throws Exception {
+    Exception actualError = null;
+    try {
+      // No snapshot should match and no exception should throw
+      deleteSnapshots(null);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+
+    try {
+      // No snapshot should match and no exception should throw
+      deleteSnapshots(Pattern.compile(""));
+    } catch (Exception ex) {
+      // H2 No Error
+      actualError = ex;
+    }
+    assertNull(actualError);
+
+    try {
+      // No snapshot should match and no exception should throw
+      deleteTableSnapshots(null, null);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+
+    try {
+      // No snapshot should match and no exception should throw
+      deleteTableSnapshots(Pattern.compile(""), Pattern.compile(""));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+  }
+
   private void checkSnapshotCount(Admin admin, int count) throws IOException {
     Assert.assertEquals(count, listSnapshotsSize(snapshotName));
   }
@@ -239,6 +353,9 @@ public abstract class AbstractTestSnapshot extends AbstractTest {
   protected abstract int listSnapshotsSize(Pattern pattern) throws IOException;
 
   protected abstract void deleteSnapshot(String snapshotName) throws IOException;
+
+  protected abstract void deleteTableSnapshots(Pattern tableName, Pattern snapshotName)
+      throws IOException;
 
   protected abstract boolean tableExists(final TableName tableName) throws IOException;
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -841,7 +841,7 @@ public abstract class AbstractBigtableAdmin implements Admin {
     Preconditions.checkNotNull(snapshotName);
     Preconditions.checkNotNull(tableName);
     if (snapshotName.isEmpty()) {
-      // this mimic the HBase behavior
+      // HBase returns an empty operation instance in case snapshotName is an empty string.
       return Operation.newBuilder().build();
     }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableAdmin.java
@@ -36,6 +36,7 @@ import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
 import com.google.cloud.bigtable.hbase.util.ModifyTableBuilder;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -837,6 +838,12 @@ public abstract class AbstractBigtableAdmin implements Admin {
    * @throws IOException if any.
    */
   protected Operation snapshotTable(String snapshotName, TableName tableName) throws IOException {
+    Preconditions.checkNotNull(snapshotName);
+    Preconditions.checkNotNull(tableName);
+    if (snapshotName.isEmpty()) {
+      // this mimic the HBase behavior
+      return Operation.newBuilder().build();
+    }
 
     SnapshotTableRequest.Builder requestBuilder =
         SnapshotTableRequest.newBuilder()
@@ -948,6 +955,11 @@ public abstract class AbstractBigtableAdmin implements Admin {
   /** {@inheritDoc} */
   @Override
   public void deleteSnapshot(String snapshotName) throws IOException {
+    Preconditions.checkNotNull(snapshotName);
+    if (snapshotName.isEmpty()) {
+      return;
+    }
+
     String btSnapshotName = getClusterName().toSnapshotName(snapshotName);
     DeleteSnapshotRequest request =
         DeleteSnapshotRequest.newBuilder().setName(btSnapshotName).build();

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
+import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
@@ -25,8 +26,30 @@ import org.apache.hadoop.hbase.TableExistsException;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotException;
+import org.junit.Test;
 
 public class TestSnapshots extends AbstractTestSnapshot {
+
+  @Test
+  public void testSnapshotWithSingleParam() throws IOException {
+    Exception actualError = null;
+    try (Admin admin = getConnection().getAdmin()) {
+      try {
+        admin.snapshot(null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+      actualError = null;
+
+      try {
+        admin.snapshot("", tableName, null);
+      } catch (Exception e) {
+        actualError = e;
+      }
+      assertNotNull(actualError);
+    }
+  }
 
   @Override
   protected void createTable(TableName tableName) throws IOException {
@@ -84,6 +107,13 @@ public class TestSnapshots extends AbstractTestSnapshot {
   protected void deleteSnapshots(Pattern pattern) throws IOException {
     try (Admin admin = getConnection().getAdmin()) {
       admin.deleteSnapshots(pattern);
+    }
+  }
+
+  @Override
+  protected void deleteTableSnapshots(Pattern tableName, Pattern snapshotName) throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      admin.deleteTableSnapshots(tableName, snapshotName);
     }
   }
 

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule.COLUMN_FAMILY;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
@@ -40,6 +41,7 @@ public class TestSnapshots extends AbstractTestSnapshot {
         actualError = e;
       }
       assertNotNull(actualError);
+      assertTrue(actualError instanceof NullPointerException);
       actualError = null;
 
       try {

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableAdmin.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableAdmin.java
@@ -21,6 +21,7 @@ import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.Snapshot;
 import com.google.cloud.bigtable.grpc.BigtableSnapshotName;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -169,6 +170,10 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   /** {@inheritDoc} */
   @Override
   public List<HBaseProtos.SnapshotDescription> listSnapshots(Pattern pattern) throws IOException {
+    if (pattern == null || pattern.matcher("").matches()) {
+      return ImmutableList.of();
+    }
+
     List<HBaseProtos.SnapshotDescription> response = new ArrayList<>();
     for (HBaseProtos.SnapshotDescription description : listSnapshots()) {
       if (pattern.matcher(description.getName()).matches()) {
@@ -187,6 +192,10 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   @Override
   public List<SnapshotDescription> listTableSnapshots(
       Pattern tableNamePattern, Pattern snapshotNamePattern) throws IOException {
+    if (tableNamePattern == null || tableNamePattern.matcher("").matches()) {
+      return ImmutableList.of();
+    }
+
     List<SnapshotDescription> response = new ArrayList<>();
     for (SnapshotDescription snapshotDescription : listSnapshots(snapshotNamePattern)) {
       if (tableNamePattern.matcher(snapshotDescription.getTable()).matches()) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestSnapshots.java
@@ -87,6 +87,13 @@ public class TestSnapshots extends AbstractTestSnapshot {
   }
 
   @Override
+  protected void deleteTableSnapshots(Pattern tableName, Pattern snapshotName) throws IOException {
+    try (Admin admin = getConnection().getAdmin()) {
+      admin.deleteTableSnapshots(tableName, snapshotName);
+    }
+  }
+
+  @Override
   protected int listTableSnapshotsSize(String tableNameRegex, String snapshotNameRegex)
       throws IOException {
     try (Admin admin = getConnection().getAdmin()) {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigtable.hbase.async;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.bigtable.hbase.AbstractTestSnapshot;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
@@ -53,6 +54,7 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
       actualError = ex;
     }
     assertNotNull(actualError);
+    assertTrue(actualError instanceof NullPointerException);
     actualError = null;
 
     try {
@@ -61,6 +63,7 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
       actualError = ex;
     }
     assertNotNull(actualError);
+    assertTrue(actualError instanceof NullPointerException);
     actualError = null;
 
     try {
@@ -80,6 +83,7 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
       actualError = ex;
     }
     assertNotNull(actualError);
+    assertTrue(actualError instanceof NullPointerException);
     actualError = null;
 
     try {
@@ -88,6 +92,7 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
       actualError = ex;
     }
     assertNotNull(actualError);
+    assertTrue(actualError instanceof NullPointerException);
     actualError = null;
 
     try {
@@ -108,6 +113,7 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
       actualError = ex;
     }
     assertNotNull(actualError);
+    assertTrue(actualError instanceof NullPointerException);
     actualError = null;
 
     try {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
@@ -16,6 +16,10 @@
 
 package com.google.cloud.bigtable.hbase.async;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
 import com.google.cloud.bigtable.hbase.AbstractTestSnapshot;
 import com.google.cloud.bigtable.hbase.test_env.SharedTestEnvRule;
 import java.io.IOException;
@@ -29,6 +33,7 @@ import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotException;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -37,6 +42,99 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
 
   private AsyncAdmin getAsyncAdmin() throws InterruptedException, ExecutionException {
     return AbstractAsyncTest.getAsyncConnection().getAdmin();
+  }
+
+  @Test
+  public void testListSnapshotsWithNullAndEmptyString() {
+    Exception actualError = null;
+    try {
+      listSnapshotsSize((String) null);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      listSnapshotsSize((Pattern) null);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      assertEquals(0, listSnapshotsSize(""));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+  }
+
+  @Test
+  public void testListTableSnapshotsWithNullAndEmptyString() {
+    Exception actualError = null;
+    try {
+      listTableSnapshotsSize(null, "");
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      listTableSnapshotsSize((Pattern) null, null);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      assertEquals(0, listTableSnapshotsSize("", ""));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+  }
+
+  @Test
+  public void testDeleteSnapshotWithEmptyString() throws Exception {
+    Exception actualError = null;
+    try {
+      // NPE is expected with AsyncAdmin.
+      deleteSnapshots(null);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      // No snapshot should match and no exception should throw
+      deleteSnapshots(Pattern.compile(""));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
+    actualError = null;
+
+    try {
+      // NPE is expected with AsyncAdmin.
+      deleteTableSnapshots(null, null);
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNotNull(actualError);
+    actualError = null;
+
+    try {
+      // No snapshot should match and no exception should throw
+      deleteTableSnapshots(Pattern.compile(""), Pattern.compile(""));
+    } catch (Exception ex) {
+      actualError = ex;
+    }
+    assertNull(actualError);
   }
 
   @Override
@@ -105,6 +203,15 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
   protected void deleteSnapshots(Pattern pattern) throws IOException {
     try {
       getAsyncAdmin().deleteSnapshots(pattern).get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new IOException("Error while deleting snapshots: " + e.getCause());
+    }
+  }
+
+  @Override
+  protected void deleteTableSnapshots(Pattern tableName, Pattern snapshotRegEx) throws IOException {
+    try {
+      getAsyncAdmin().deleteTableSnapshots(tableName, snapshotRegEx).get();
     } catch (InterruptedException | ExecutionException e) {
       throw new IOException("Error while deleting snapshots: " + e.getCause());
     }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
@@ -46,7 +46,7 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
   }
 
   @Test
-  public void testListSnapshotsWithNullAndEmptyString() {
+  public void testListSnapshotsWithNullAndEmptyString() throws IOException {
     Exception actualError = null;
     try {
       listSnapshotsSize((String) null);
@@ -64,18 +64,12 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
     }
     assertNotNull(actualError);
     assertTrue(actualError instanceof NullPointerException);
-    actualError = null;
 
-    try {
-      assertEquals(0, listSnapshotsSize(""));
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
+    assertEquals(0, listSnapshotsSize(""));
   }
 
   @Test
-  public void testListTableSnapshotsWithNullAndEmptyString() {
+  public void testListTableSnapshotsWithNullAndEmptyString() throws IOException {
     Exception actualError = null;
     try {
       listTableSnapshotsSize(null, "");
@@ -93,14 +87,8 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
     }
     assertNotNull(actualError);
     assertTrue(actualError instanceof NullPointerException);
-    actualError = null;
 
-    try {
-      assertEquals(0, listTableSnapshotsSize("", ""));
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
+    assertEquals(0, listTableSnapshotsSize("", ""));
   }
 
   @Test
@@ -117,15 +105,6 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
     actualError = null;
 
     try {
-      // No snapshot should match and no exception should throw
-      deleteSnapshots(Pattern.compile(""));
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
-    actualError = null;
-
-    try {
       // NPE is expected with AsyncAdmin.
       deleteTableSnapshots(null, null);
     } catch (Exception ex) {
@@ -135,7 +114,9 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
     actualError = null;
 
     try {
-      // No snapshot should match and no exception should throw
+      // No snapshot matches hence no exception should be thrown
+      deleteSnapshots(Pattern.compile(""));
+
       deleteTableSnapshots(Pattern.compile(""), Pattern.compile(""));
     } catch (Exception ex) {
       actualError = ex;

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncSnapshots.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.hbase.async;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.bigtable.hbase.AbstractTestSnapshot;
@@ -111,17 +110,11 @@ public class TestAsyncSnapshots extends AbstractTestSnapshot {
       actualError = ex;
     }
     assertNotNull(actualError);
-    actualError = null;
 
-    try {
-      // No snapshot matches hence no exception should be thrown
-      deleteSnapshots(Pattern.compile(""));
+    // No snapshot matches hence no exception should be thrown
+    deleteSnapshots(Pattern.compile(""));
 
-      deleteTableSnapshots(Pattern.compile(""), Pattern.compile(""));
-    } catch (Exception ex) {
-      actualError = ex;
-    }
-    assertNull(actualError);
+    deleteTableSnapshots(Pattern.compile(""), Pattern.compile(""));
   }
 
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
@@ -21,6 +21,7 @@ import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.Snapshot;
 import com.google.cloud.bigtable.hbase.util.ModifyTableBuilder;
 import com.google.cloud.bigtable.hbase2_x.adapters.admin.TableAdapter2x;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -126,6 +127,10 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   /** {@inheritDoc} */
   @Override
   public List<SnapshotDescription> listSnapshots(Pattern pattern) throws IOException {
+    if (pattern == null || pattern.matcher("").matches()) {
+      return ImmutableList.of();
+    }
+
     List<SnapshotDescription> response = new ArrayList<>();
     for (SnapshotDescription description : listSnapshots()) {
       if (pattern.matcher(description.getName()).matches()) {
@@ -306,6 +311,10 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   @Override
   public List<SnapshotDescription> listTableSnapshots(Pattern tableName, Pattern snapshotName)
       throws IOException {
+    if (tableName == null || tableName.matcher("").matches()) {
+      return ImmutableList.of();
+    }
+
     List<SnapshotDescription> response = new ArrayList<>();
     for (SnapshotDescription snapshot : listSnapshots(snapshotName)) {
       if (tableName.matcher(snapshot.getTableNameAsString()).matches()) {


### PR DESCRIPTION
This change includes sanitary checks to Snapshot operation.

## What is the problem:
If an empty string is being passed on to snapshot operations(#snapshotTable, #listSnapshot) then it fails with `Unimplemented method found` exception message.
```
com.google.bigtable.repackaged.com.google.common.util.concurrent.UncheckedExecutionException: com.google.bigtable.repackaged.io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method not found.
```

## Impact of this change:
Now snapshot operations would not fail with `""` anymore. Also, These methods will behave same as HBase API when passing empty string or `null`.