### PR TITLE
refactor: removes BigtableTableName references

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -702,10 +702,12 @@ public class BigtableSession implements Closeable {
    * alternative.
    */
   @InternalApi("For internal usage only")
-  public IBulkMutation createBulkMutationWrapper(BigtableTableName tableName) {
+  public IBulkMutation createBulkMutationWrapper(String tableId) {
     if (options.useGCJClient()) {
-      return getDataClientWrapper().createBulkMutationBatcher(tableName.getTableId());
+      return getDataClientWrapper().createBulkMutationBatcher(tableId);
     } else {
+      BigtableTableName tableName =
+          new BigtableTableName(options.getInstanceName().toTableNameStr(tableId));
       return new BulkMutationWrapper(createBulkMutation(tableName));
     }
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
@@ -185,19 +185,16 @@ public class TestAppProfile {
 
   @Test
   public void testBulkMutation() throws Exception {
-    BigtableTableName fakeTableName =
-        new BigtableTableName("projects/fake-project/instances/fake-instance/tables/fake-table");
-
     RowMutationEntry rowMutation = RowMutationEntry.create("fake-key");
 
-    IBulkMutation bulkMutation = defaultSession.createBulkMutationWrapper(fakeTableName);
+    IBulkMutation bulkMutation = defaultSession.createBulkMutationWrapper(TABLE_ID);
     bulkMutation.add(rowMutation);
     bulkMutation.flush();
 
     MutateRowsRequest req = fakeDataService.popLastRequest();
     Preconditions.checkState(req.getAppProfileId().isEmpty());
 
-    IBulkMutation bulkMutation2 = profileSession.createBulkMutationWrapper(fakeTableName);
+    IBulkMutation bulkMutation2 = profileSession.createBulkMutationWrapper(TABLE_ID);
     bulkMutation2.add(rowMutation);
     bulkMutation2.flush();
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -23,6 +23,7 @@ import com.google.api.core.SettableApiFuture;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableSession;
+import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.async.BulkRead;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
@@ -145,7 +146,9 @@ public class BatchExecutor {
   public BatchExecutor(BigtableSession session, HBaseRequestAdapter requestAdapter) {
     this.requestAdapter = requestAdapter;
     this.options = session.getOptions();
-    this.bulkRead = session.createBulkRead(requestAdapter.getBigtableTableName());
+    // TODO(rahulkql): remove BigtableTableName from here once IBulkRead is implemented
+    this.bulkRead =
+        session.createBulkRead(new BigtableTableName(requestAdapter.getBigtableTableName()));
     this.bufferedMutatorHelper =
         new BigtableBufferedMutatorHelper(
             requestAdapter,

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -23,7 +23,6 @@ import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.grpc.BigtableSession;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.async.OperationAccountant;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.util.ApiFutureUtil;
@@ -84,8 +83,8 @@ public class BigtableBufferedMutatorHelper {
     this.adapter = adapter;
     this.configuration = configuration;
     this.options = session.getOptions();
-    BigtableTableName tableName = this.adapter.getBigtableTableName();
-    this.bulkMutation = session.createBulkMutationWrapper(tableName);
+    this.bulkMutation =
+        session.createBulkMutationWrapper(this.adapter.getTableName().getNameAsString());
     this.dataClient = session.getDataClientWrapper();
     this.operationAccountant = new OperationAccountant();
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
@@ -213,7 +213,7 @@ public class CheckAndMutateUtil {
               + " calling ifNotExists/ifEquals/ifMatches before executing the request");
       ConditionalRowMutation conditionalRowMutation =
           ConditionalRowMutation.create(
-              hbaseAdapter.getBigtableTableName().getTableId(), ByteString.copyFrom(row));
+              hbaseAdapter.getTableName().getNameAsString(), ByteString.copyFrom(row));
       Scan scan = new Scan();
       scan.setMaxVersions(1);
       scan.addColumn(family, qualifier);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -17,13 +17,13 @@ package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.MutationApi;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
 import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
 import com.google.common.annotations.VisibleForTesting;
@@ -71,7 +71,7 @@ public class HBaseRequestAdapter {
 
   protected final MutationAdapters mutationAdapters;
   protected final TableName tableName;
-  protected final BigtableTableName bigtableTableName;
+  protected final String bigtableTableName;
 
   /**
    * Constructor for HBaseRequestAdapter.
@@ -95,7 +95,8 @@ public class HBaseRequestAdapter {
       BigtableOptions options, TableName tableName, MutationAdapters mutationAdapters) {
     this(
         tableName,
-        options.getInstanceName().toTableName(tableName.getQualifierAsString()),
+        NameUtil.formatTableName(
+            options.getProjectId(), options.getInstanceId(), tableName.getNameAsString()),
         mutationAdapters);
   }
 
@@ -103,12 +104,12 @@ public class HBaseRequestAdapter {
    * Constructor for HBaseRequestAdapter.
    *
    * @param tableName a {@link TableName} object.
-   * @param bigtableTableName a {@link BigtableTableName} object.
+   * @param bigtableTableName a {@link String} object.
    * @param mutationAdapters a {@link MutationAdapters} object.
    */
   @VisibleForTesting
   HBaseRequestAdapter(
-      TableName tableName, BigtableTableName bigtableTableName, MutationAdapters mutationAdapters) {
+      TableName tableName, String bigtableTableName, MutationAdapters mutationAdapters) {
     this.tableName = tableName;
     this.bigtableTableName = bigtableTableName;
     this.mutationAdapters = mutationAdapters;
@@ -162,7 +163,7 @@ public class HBaseRequestAdapter {
    */
   public Query adapt(Get get) {
     ReadHooks readHooks = new DefaultReadHooks();
-    Query query = Query.create(bigtableTableName.getTableId());
+    Query query = Query.create(tableName.getNameAsString());
     Adapters.GET_ADAPTER.adapt(get, readHooks, query);
     readHooks.applyPreSendHook(query);
     return query;
@@ -176,7 +177,7 @@ public class HBaseRequestAdapter {
    */
   public Query adapt(Scan scan) {
     ReadHooks readHooks = new DefaultReadHooks();
-    Query query = Query.create(bigtableTableName.getTableId());
+    Query query = Query.create(tableName.getNameAsString());
     Adapters.SCAN_ADAPTER.adapt(scan, readHooks, query);
     readHooks.applyPreSendHook(query);
     return query;
@@ -191,7 +192,7 @@ public class HBaseRequestAdapter {
   public ReadModifyWriteRow adapt(Append append) {
     ReadModifyWriteRow readModifyWriteRow =
         ReadModifyWriteRow.create(
-            bigtableTableName.getTableId(), ByteString.copyFrom(append.getRow()));
+            tableName.getNameAsString(), ByteString.copyFrom(append.getRow()));
     Adapters.APPEND_ADAPTER.adapt(append, readModifyWriteRow);
     return readModifyWriteRow;
   }
@@ -205,7 +206,7 @@ public class HBaseRequestAdapter {
   public ReadModifyWriteRow adapt(Increment increment) {
     ReadModifyWriteRow readModifyWriteRow =
         ReadModifyWriteRow.create(
-            bigtableTableName.getTableId(), ByteString.copyFrom(increment.getRow()));
+            tableName.getNameAsString(), ByteString.copyFrom(increment.getRow()));
     Adapters.INCREMENT_ADAPTER.adapt(increment, readModifyWriteRow);
     return readModifyWriteRow;
   }
@@ -305,9 +306,9 @@ public class HBaseRequestAdapter {
   /**
    * Getter for the field <code>bigtableTableName</code>.
    *
-   * @return a {@link com.google.cloud.bigtable.grpc.BigtableTableName} object.
+   * @return a complete table name as a string.
    */
-  public BigtableTableName getBigtableTableName() {
+  public String getBigtableTableName() {
     return bigtableTableName;
   }
 
@@ -323,9 +324,9 @@ public class HBaseRequestAdapter {
   private RowMutation newRowMutationModel(byte[] rowKey) {
     if (!mutationAdapters.putAdapter.isSetClientTimestamp()) {
       return RowMutation.create(
-          bigtableTableName.getTableId(), ByteString.copyFrom(rowKey), Mutation.createUnsafe());
+          tableName.getNameAsString(), ByteString.copyFrom(rowKey), Mutation.createUnsafe());
     }
-    return RowMutation.create(bigtableTableName.getTableId(), ByteString.copyFrom(rowKey));
+    return RowMutation.create(tableName.getNameAsString(), ByteString.copyFrom(rowKey));
   }
 
   private RowMutationEntry buildRowMutationEntry(byte[] rowKey) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -134,7 +134,7 @@ public class TestBatchExecutor {
     when(mockBigtableSession.getDataClientWrapper()).thenReturn(mockDataClient);
     when(mockDataClient.readModifyWriteRowAsync(any(ReadModifyWriteRow.class)))
         .thenReturn(mockFuture);
-    when(mockBigtableSession.createBulkMutationWrapper(any(BigtableTableName.class)))
+    when(mockBigtableSession.createBulkMutationWrapper(any(String.class)))
         .thenReturn(mockBulkMutation);
     when(mockBigtableSession.createBulkRead(any(BigtableTableName.class))).thenReturn(mockBulkRead);
     doAnswer(

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -31,7 +31,6 @@ import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.grpc.BigtableSession;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
@@ -77,8 +76,7 @@ public class TestBigtableBufferedMutator {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    when(mockSession.createBulkMutationWrapper(any(BigtableTableName.class)))
-        .thenReturn(mockBulkMutation);
+    when(mockSession.createBulkMutationWrapper(any(String.class))).thenReturn(mockBulkMutation);
     when(mockSession.getDataClientWrapper()).thenReturn(mockDataClient);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
@@ -20,10 +20,9 @@ import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
 import com.google.bigtable.v2.CheckAndMutateRowRequest;
 import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Filters;
-import com.google.cloud.bigtable.grpc.BigtableInstanceName;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -49,8 +48,8 @@ public class TestCheckAndMutateUtil {
   private static final String PROJECT_ID = "project";
   private static final String INSTANCE_ID = "instance";
   private static final TableName TABLE_NAME = TableName.valueOf("SomeTable");
-  private static final BigtableTableName BT_TABLE_NAME =
-      new BigtableInstanceName(PROJECT_ID, INSTANCE_ID).toTableName(TABLE_NAME.getNameAsString());
+  private static final String BT_TABLE_NAME =
+      NameUtil.formatTableName(PROJECT_ID, INSTANCE_ID, TABLE_NAME.getNameAsString());
   private static final RequestContext REQUEST_CONTEXT =
       RequestContext.create(PROJECT_ID, INSTANCE_ID, "SomeAppProfileId");
   private static final byte[] rowKey = Bytes.toBytes("rowKey");

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableAdmin.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableAdmin.java
@@ -19,8 +19,8 @@ import com.google.api.core.InternalApi;
 import com.google.bigtable.admin.v2.ListSnapshotsRequest;
 import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.Snapshot;
+import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.grpc.BigtableSnapshotName;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
@@ -150,11 +150,10 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
 
     for (Snapshot snapshot : snapshotList.getSnapshotsList()) {
       BigtableSnapshotName snapshotName = new BigtableSnapshotName(snapshot.getName());
-      BigtableTableName tableName = new BigtableTableName(snapshot.getSourceTable().getName());
       response.add(
           HBaseProtos.SnapshotDescription.newBuilder()
               .setName(snapshotName.getSnapshotId())
-              .setTable(tableName.getTableId())
+              .setTable(NameUtil.extractTableIdFromTableName(snapshot.getSourceTable().getName()))
               .setCreationTime(TimeUnit.SECONDS.toMillis(snapshot.getCreateTime().getSeconds()))
               .build());
     }


### PR DESCRIPTION
This PR removes references of bigtable-core-client's `BigtableTableName` from bigtable-hbase module.

*Note:* The affected classes/methods are already marked as `@InternalApi`.