### PR TITLE
feature: introducing IBigtableSession with core-client classes

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/core/IBigtableSession.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.core;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.grpc.BigtableInstanceClient;
+import com.google.cloud.bigtable.grpc.BigtableTableName;
+import com.google.cloud.bigtable.grpc.async.BulkRead;
+import java.io.IOException;
+
+@InternalApi
+public interface IBigtableSession extends AutoCloseable {
+
+  IBigtableDataClient getDataClient();
+
+  IBigtableTableAdminClient getTableAdminClient() throws IOException;
+
+  // TODO: Decide if this should be added or not. considering Instance op are deprecated.
+  BigtableInstanceClient getInstanceAdminClient() throws IOException;
+
+  IBulkMutation createBulkMutation(BigtableTableName tableName);
+
+  BulkRead createBulkRead(BigtableTableName tableName);
+
+  /** For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
+  BigtableOptions getOptions();
+
+  void close() throws IOException;
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSessionClassicClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSessionClassicClient.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.core.IBigtableSession;
+import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
+import com.google.cloud.bigtable.core.IBulkMutation;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.grpc.async.BulkMutationWrapper;
+import com.google.cloud.bigtable.grpc.async.BulkRead;
+import java.io.IOException;
+
+/**
+ * Wraps and delegate calls to existing {@link BigtableSession}.
+ *
+ * <p>For internal use only - public for technical reasons.
+ *
+ * <p>See {@link BigtableSession} as a public alternative.
+ */
+@InternalApi("For internal usage only - please use BigtableSession")
+public class BigtableSessionClassicClient implements IBigtableSession {
+
+  private final BigtableSession session;
+
+  public BigtableSessionClassicClient(BigtableOptions options) throws IOException {
+    this.session = new BigtableSession(options);
+  }
+
+  @Override
+  public IBigtableDataClient getDataClient() {
+    return new BigtableDataClientWrapper(
+        session.getDataClient(),
+        RequestContext.create(
+            getOptions().getProjectId(),
+            getOptions().getInstanceId(),
+            getOptions().getAppProfileId()));
+  }
+
+  @Override
+  public IBigtableTableAdminClient getTableAdminClient() throws IOException {
+    return new BigtableTableAdminClientWrapper(session.getTableAdminClient(), getOptions());
+  }
+
+  @Override
+  public BigtableInstanceClient getInstanceAdminClient() throws IOException {
+    return session.getInstanceAdminClient();
+  }
+
+  @Override
+  public IBulkMutation createBulkMutation(BigtableTableName tableName) {
+    return new BulkMutationWrapper(session.createBulkMutation(tableName));
+  }
+
+  @Override
+  public BulkRead createBulkRead(BigtableTableName tableName) {
+    return session.createBulkRead(tableName);
+  }
+
+  @Override
+  public BigtableOptions getOptions() {
+    return session.getOptions();
+  }
+
+  @Override
+  public void close() throws IOException {
+    session.close();
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -19,10 +19,10 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.core.IBigtableSession;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
-import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.CheckAndMutateUtil;
@@ -123,9 +123,9 @@ public abstract class AbstractBigtableTable implements Table {
   public AbstractBigtableTable(
       AbstractBigtableConnection bigtableConnection, HBaseRequestAdapter hbaseAdapter) {
     this.bigtableConnection = bigtableConnection;
-    BigtableSession session = bigtableConnection.getSession();
+    IBigtableSession session = bigtableConnection.getSession();
     this.options = session.getOptions();
-    this.clientWrapper = session.getDataClientWrapper();
+    this.clientWrapper = session.getDataClient();
     this.hbaseAdapter = hbaseAdapter;
     this.tableName = hbaseAdapter.getTableName();
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -22,7 +22,7 @@ import com.google.api.core.InternalApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
-import com.google.cloud.bigtable.grpc.BigtableSession;
+import com.google.cloud.bigtable.core.IBigtableSession;
 import com.google.cloud.bigtable.grpc.async.BulkRead;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
@@ -142,7 +142,7 @@ public class BatchExecutor {
    * @param requestAdapter a {@link com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter}
    *     object.
    */
-  public BatchExecutor(BigtableSession session, HBaseRequestAdapter requestAdapter) {
+  public BatchExecutor(IBigtableSession session, HBaseRequestAdapter requestAdapter) {
     this.requestAdapter = requestAdapter;
     this.options = session.getOptions();
     this.bulkRead = session.createBulkRead(requestAdapter.getBigtableTableName());

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -20,6 +20,7 @@ import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.Logger;
+import com.google.cloud.bigtable.core.IBigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -71,7 +72,7 @@ public class BigtableBufferedMutator implements BufferedMutator {
   public BigtableBufferedMutator(
       HBaseRequestAdapter adapter,
       Configuration configuration,
-      BigtableSession session,
+      IBigtableSession session,
       BufferedMutator.ExceptionListener listener) {
     helper = new BigtableBufferedMutatorHelper(adapter, configuration, session);
     this.listener = listener;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -21,6 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.core.IBigtableSession;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
@@ -80,13 +81,13 @@ public class BigtableBufferedMutatorHelper {
    * @param session a {@link BigtableSession} object.
    */
   public BigtableBufferedMutatorHelper(
-      HBaseRequestAdapter adapter, Configuration configuration, BigtableSession session) {
+      HBaseRequestAdapter adapter, Configuration configuration, IBigtableSession session) {
     this.adapter = adapter;
     this.configuration = configuration;
     this.options = session.getOptions();
     BigtableTableName tableName = this.adapter.getBigtableTableName();
-    this.bulkMutation = session.createBulkMutationWrapper(tableName);
-    this.dataClient = session.getDataClientWrapper();
+    this.bulkMutation = session.createBulkMutation(tableName);
+    this.dataClient = session.getDataClient();
     this.operationAccountant = new OperationAccountant();
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrapper/BigtableSessionGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrapper/BigtableSessionGCJClient.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrapper;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.core.IBigtableSession;
+import com.google.cloud.bigtable.core.IBigtableTableAdminClient;
+import com.google.cloud.bigtable.core.IBulkMutation;
+import com.google.cloud.bigtable.grpc.BigtableInstanceClient;
+import com.google.cloud.bigtable.grpc.BigtableSession;
+import com.google.cloud.bigtable.grpc.BigtableTableName;
+import com.google.cloud.bigtable.grpc.async.BulkRead;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+
+// TODO: JavaDoc
+/**
+ * For internal use only - public for technical reasons.
+ *
+ * <p>See {@link BigtableSession} as a public alternative.
+ */
+@InternalApi("For internal usage only")
+public class BigtableSessionGCJClient implements IBigtableSession {
+
+  private final BigtableSession delegate;
+
+  // Argument is kept Configuration to support veneer settings in future
+  public BigtableSessionGCJClient(Configuration configuration) throws IOException {
+    this.delegate = new BigtableSession(BigtableOptionsFactory.fromConfiguration(configuration));
+  }
+
+  @Override
+  public IBigtableDataClient getDataClient() {
+    return delegate.getDataClientWrapper();
+  }
+
+  @Override
+  public IBigtableTableAdminClient getTableAdminClient() throws IOException {
+    return delegate.getTableAdminClientWrapper();
+  }
+
+  @Override
+  public BigtableInstanceClient getInstanceAdminClient() throws IOException {
+    return delegate.getInstanceAdminClient();
+  }
+
+  @Override
+  public IBulkMutation createBulkMutation(BigtableTableName tableName) {
+    return delegate.createBulkMutationWrapper(tableName);
+  }
+
+  @Override
+  public BulkRead createBulkRead(BigtableTableName tableName) {
+    return delegate.createBulkRead(tableName);
+  }
+
+  @Override
+  public BigtableOptions getOptions() {
+    return delegate.getOptions();
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
@@ -10,6 +10,7 @@ package org.apache.hadoop.hbase.client;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.core.IBigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import java.io.Closeable;
 import java.io.IOException;
@@ -32,7 +33,7 @@ public interface CommonConnection extends Closeable {
    *
    * @return a {@link BigtableSession} object.
    */
-  BigtableSession getSession();
+  IBigtableSession getSession();
 
   /**
    * Returns the {@link Configuration} object used by this instance. The reference returned is not a

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -28,11 +28,11 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.core.IBigtableSession;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
-import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.grpc.async.BulkRead;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
@@ -108,7 +108,7 @@ public class TestBatchExecutor {
     };
   }
 
-  @Mock private BigtableSession mockBigtableSession;
+  @Mock private IBigtableSession mockBigtableSession;
 
   @Mock private BulkRead mockBulkRead;
 
@@ -131,10 +131,10 @@ public class TestBatchExecutor {
 
     MockitoAnnotations.initMocks(this);
     when(mockBulkMutation.add(any(RowMutationEntry.class))).thenReturn(mockFuture);
-    when(mockBigtableSession.getDataClientWrapper()).thenReturn(mockDataClient);
+    when(mockBigtableSession.getDataClient()).thenReturn(mockDataClient);
     when(mockDataClient.readModifyWriteRowAsync(any(ReadModifyWriteRow.class)))
         .thenReturn(mockFuture);
-    when(mockBigtableSession.createBulkMutationWrapper(any(BigtableTableName.class)))
+    when(mockBigtableSession.createBulkMutation(any(BigtableTableName.class)))
         .thenReturn(mockBulkMutation);
     when(mockBigtableSession.createBulkRead(any(BigtableTableName.class))).thenReturn(mockBulkRead);
     doAnswer(

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -27,10 +27,10 @@ import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.core.IBigtableSession;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
-import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import java.io.IOException;
@@ -61,7 +61,7 @@ public class TestBigtableBufferedMutator {
   private static final Put SIMPLE_PUT =
       new Put(EMPTY_BYTES).addColumn(EMPTY_BYTES, EMPTY_BYTES, EMPTY_BYTES);
 
-  @Mock private BigtableSession mockSession;
+  @Mock private IBigtableSession mockSession;
 
   @Mock private IBulkMutation mockBulkMutation;
 
@@ -77,9 +77,8 @@ public class TestBigtableBufferedMutator {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    when(mockSession.createBulkMutationWrapper(any(BigtableTableName.class)))
-        .thenReturn(mockBulkMutation);
-    when(mockSession.getDataClientWrapper()).thenReturn(mockDataClient);
+    when(mockSession.createBulkMutation(any(BigtableTableName.class))).thenReturn(mockBulkMutation);
+    when(mockSession.getDataClient()).thenReturn(mockDataClient);
   }
 
   @After

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -28,10 +28,10 @@ import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.RetryOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.core.IBigtableSession;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
-import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
@@ -74,7 +74,7 @@ public class TestBigtableTable {
 
   @Mock private AbstractBigtableConnection mockConnection;
 
-  @Mock private BigtableSession mockSession;
+  @Mock private IBigtableSession mockSession;
 
   @Mock private IBigtableDataClient mockBigtableDataClient;
 
@@ -104,7 +104,7 @@ public class TestBigtableTable {
     when(mockConnection.getConfiguration()).thenReturn(config);
     when(mockConnection.getSession()).thenReturn(mockSession);
     when(mockSession.getOptions()).thenReturn(options);
-    when(mockSession.getDataClientWrapper()).thenReturn(mockBigtableDataClient);
+    when(mockSession.getDataClient()).thenReturn(mockBigtableDataClient);
     when(mockBigtableDataClient.readFlatRows(isA(Query.class))).thenReturn(mockResultScanner);
     table = new AbstractBigtableTable(mockConnection, hbaseAdapter) {};
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
@@ -18,7 +18,7 @@ package com.google.cloud.bigtable.hbase2_x;
 import static com.google.cloud.bigtable.hbase2_x.FutureUtils.toCompletableFuture;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.grpc.BigtableSession;
+import com.google.cloud.bigtable.core.IBigtableSession;
 import com.google.cloud.bigtable.hbase.BigtableBufferedMutatorHelper;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import java.util.List;
@@ -47,7 +47,7 @@ public class BigtableAsyncBufferedMutator implements AsyncBufferedMutator {
    * @param session a {@link com.google.cloud.bigtable.grpc.BigtableSession}
    */
   public BigtableAsyncBufferedMutator(
-      HBaseRequestAdapter adapter, Configuration configuration, BigtableSession session) {
+      HBaseRequestAdapter adapter, Configuration configuration, IBigtableSession session) {
     helper = new BigtableBufferedMutatorHelper(adapter, configuration, session);
   }
 

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -85,7 +85,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
 
   public BigtableAsyncTable(CommonConnection connection, HBaseRequestAdapter hbaseAdapter) {
     this.connection = connection;
-    this.clientWrapper = connection.getSession().getDataClientWrapper();
+    this.clientWrapper = connection.getSession().getDataClient();
     this.hbaseAdapter = hbaseAdapter;
     this.tableName = hbaseAdapter.getTableName();
   }


### PR DESCRIPTION
This change introduces IBigtableSession with two implementation

1. **BigtableSessionClassicClient**: This impl is a wrapper over existing data/admin client.

2. **BigtableSessionGCJClient**: This impl returns veneer specific Data, Admin, and BulkMutation client. Due to the non-availability of `BulkRead` & `BigtableInstanceAdminClient`, I continued with existing classes. _We would update these with veneer classes in the future._