### PR TITLE
feat: introducing veneer implementation for wrapper interfaces

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableExtendedConfiguration.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableExtendedConfiguration.java
@@ -10,7 +10,7 @@ import org.apache.hadoop.conf.Configuration;
  * @see BigtableConfiguration#withCredentials(Configuration, Credentials).
  */
 @InternalExtensionOnly
-class BigtableExtendedConfiguration extends Configuration {
+public class BigtableExtendedConfiguration extends Configuration {
   private Credentials credentials;
 
   BigtableExtendedConfiguration(Configuration conf, Credentials credentials) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ResultRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ResultRowAdapter.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.read;
+
+import com.google.cloud.bigtable.data.v2.models.RowAdapter;
+import com.google.cloud.bigtable.hbase.util.ByteStringer;
+import com.google.cloud.bigtable.hbase.util.TimestampConverter;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.client.Result;
+
+// TODO(WARNING): The implementation is not finalized. It needs to be updated accordingly.
+public class ResultRowAdapter implements RowAdapter<Result> {
+
+  @Override
+  public RowBuilder<Result> createRowBuilder() {
+    return new ResultRowBuilder();
+  }
+
+  @Override
+  public boolean isScanMarkerRow(Result result) {
+    return result.isEmpty();
+  }
+
+  @Override
+  public ByteString getKey(Result result) {
+    return ByteString.copyFrom(result.getRow());
+  }
+
+  public static class ResultRowBuilder implements RowBuilder<Result> {
+    private ByteString currentKey;
+    private String family;
+    private ByteString qualifier;
+    private List<String> labels;
+    private long timestamp;
+    private ByteString value;
+
+    /*
+     * cells contains list of {@link Cell} for all the families.
+     */
+    private Map<String, List<RowCell>> cells = new TreeMap<>();
+
+    /*
+     * currentFamilyCells is buffered with current family's {@link Cell}s.
+     */
+    private List<RowCell> currentFamilyCells = null;
+    private String previousFamily;
+    private int totalCellCount = 0;
+
+    @Override
+    public void startRow(ByteString byteString) {
+      this.currentKey = byteString;
+    }
+
+    @Override
+    public void startCell(
+        String family, ByteString qualifier, long timestamp, List<String> labels, long size) {
+      this.family = family;
+      this.qualifier = qualifier;
+      this.timestamp = timestamp;
+      this.labels = labels;
+      this.value = ByteString.EMPTY;
+    }
+
+    @Override
+    public void cellValue(ByteString value) {
+      this.value = this.value.concat(value);
+    }
+
+    @Override
+    public void finishCell() {
+      if (!Objects.equals(this.family, this.previousFamily)) {
+        previousFamily = this.family;
+        currentFamilyCells = new ArrayList<>();
+        cells.put(this.family, this.currentFamilyCells);
+      }
+
+      RowCell rowCell =
+          new RowCell(
+              this.currentKey.toByteArray(),
+              this.family.getBytes(),
+              ByteStringer.extract(this.qualifier),
+              // Bigtable timestamp has more granularity than HBase one. It is possible that
+              // Bigtable
+              // cells are deduped unintentionally here. On the other hand, if we don't dedup them,
+              // HBase will treat them as duplicates.
+              TimestampConverter.bigtable2hbase(this.timestamp),
+              this.labels,
+              ByteStringer.extract(this.value));
+      this.currentFamilyCells.add(rowCell);
+      totalCellCount++;
+    }
+
+    @Override
+    public Result finishRow() {
+      ImmutableList.Builder<RowCell> combined = ImmutableList.builder();
+      for (List<RowCell> familyCellList : cells.values()) {
+        RowCell previous = null;
+        for (RowCell c : familyCellList) {
+          if (previous == null || !c.getLabels().isEmpty() || !keysMatch(c, previous)) {
+            combined.add(c);
+          }
+          previous = c;
+        }
+      }
+
+      return Result.create(new ArrayList<Cell>(combined.build()));
+    }
+
+    @Override
+    public void reset() {
+      this.currentKey = null;
+      this.family = null;
+      this.qualifier = null;
+      this.labels = null;
+      this.timestamp = 0L;
+      this.value = null;
+      this.cells = new TreeMap<>();
+      this.currentFamilyCells = null;
+      this.previousFamily = null;
+      this.totalCellCount = 0;
+    }
+
+    @Override
+    public Result createScanMarkerRow(ByteString rowKey) {
+      return new Result();
+    }
+
+    private boolean keysMatch(RowCell current, RowCell previous) {
+      return current.getTimestamp() == previous.getTimestamp()
+          && Arrays.equals(current.getQualifierArray(), previous.getQualifierArray())
+          && Objects.equals(current.getLabels(), previous.getLabels());
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ResultScannerExtended.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/ResultScannerExtended.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.adapters.read;
+
+import com.google.api.core.InternalApi;
+import com.google.api.gax.rpc.ServerStream;
+import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
+import com.google.cloud.bigtable.metrics.BigtableClientMetrics;
+import com.google.cloud.bigtable.metrics.Meter;
+import com.google.cloud.bigtable.metrics.Timer;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+// Copied from bigtable-core-client as it is.
+/**
+ * A {@link ResultScanner} that wraps GCJ {@link ServerStream}.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
+public class ResultScannerExtended<T> implements ResultScanner<T> {
+
+  private static final Meter resultsMeter =
+      BigtableClientMetrics.meter(BigtableClientMetrics.MetricLevel.Info, "scanner.results");
+  private static final Timer resultsTimer =
+      BigtableClientMetrics.timer(
+          BigtableClientMetrics.MetricLevel.Debug, "scanner.results.latency");
+
+  private final ServerStream<T> stream;
+  private final Iterator<T> iterator;
+  private final T[] arr;
+
+  /**
+   * @param stream a Stream of type Row/FlatRow.
+   * @param arr An array of type T length zero.
+   */
+  public ResultScannerExtended(ServerStream<T> stream, T[] arr) {
+    this.stream = stream;
+    this.iterator = stream.iterator();
+    this.arr = arr;
+  }
+
+  @Override
+  public T next() {
+    if (!iterator.hasNext()) {
+      return null;
+    }
+
+    try (Timer.Context ignored = resultsTimer.time()) {
+      T result = iterator.next();
+      resultsMeter.mark();
+      return result;
+    } catch (RuntimeException e) {
+      throw e;
+    }
+  }
+
+  @Override
+  public T[] next(int count) {
+    ArrayList<T> resultList = new ArrayList<>(count);
+    for (int i = 0; iterator.hasNext() && i < count; i++) {
+      T row = next();
+      if (row == null) {
+        break;
+      }
+      resultList.add(row);
+    }
+    return resultList.toArray(arr);
+  }
+
+  @Override
+  public int available() {
+    return stream.isReceiveReady() ? 1 : 0;
+  }
+
+  @Override
+  public void close() {
+    if (iterator.hasNext()) {
+      stream.cancel();
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowCell.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowCell.java
@@ -14,6 +14,8 @@
 package com.google.cloud.bigtable.hbase.adapters.read;
 
 import com.google.api.core.InternalApi;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.HConstants;
@@ -38,6 +40,7 @@ public class RowCell implements Cell {
   private final byte[] qualifierArray;
   private final long timestamp;
   private final byte[] valueArray;
+  private final List<String> labelArray;
 
   /**
    * Constructor for RowCell.
@@ -54,11 +57,31 @@ public class RowCell implements Cell {
       byte[] qualifierArray,
       long timestamp,
       byte[] valueArray) {
+    this(rowArray, familyArray, qualifierArray, timestamp, ImmutableList.<String>of(), valueArray);
+  }
+
+  /**
+   * Constructor for RowCell.
+   *
+   * @param rowArray an array of byte.
+   * @param familyArray an array of byte.
+   * @param qualifierArray an array of byte.
+   * @param timestamp a long.
+   * @param valueArray an array of byte.
+   */
+  public RowCell(
+      byte[] rowArray,
+      byte[] familyArray,
+      byte[] qualifierArray,
+      long timestamp,
+      List<String> labelArray,
+      byte[] valueArray) {
     this.rowArray = rowArray;
     this.familyArray = familyArray;
     this.qualifierArray = qualifierArray;
     this.timestamp = timestamp;
     this.valueArray = valueArray;
+    this.labelArray = labelArray;
   }
 
   /** {@inheritDoc} */
@@ -138,6 +161,10 @@ public class RowCell implements Cell {
   @Override
   public long getSequenceId() {
     return 0;
+  }
+
+  public List<String> getLabels() {
+    return labelArray;
   }
 
   /** {@inheritDoc} */
@@ -225,6 +252,7 @@ public class RowCell implements Cell {
   //
   // ---------------------------------------------------------------------------
 
+  // TODO: add labels in this toString().
   @Override
   public String toString() {
     if (this.rowArray == null || this.rowArray.length == 0) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/AdminClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/AdminClientWrapper.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
+import com.google.cloud.bigtable.admin.v2.models.Table;
+import java.util.List;
+
+public interface AdminClientWrapper extends AutoCloseable {
+
+  /**
+   * Creates a new table asynchronously. The table can be created with a full set of initial column
+   * families, specified in the request.
+   *
+   * @param request a {@link CreateTableRequest} object.
+   */
+  ApiFuture<Table> createTableAsync(CreateTableRequest request);
+
+  /**
+   * Gets the details of a table asynchronously.
+   *
+   * @return a {@link ApiFuture} that returns a {@link Table} object.
+   */
+  ApiFuture<Table> getTableAsync(String tableId);
+
+  /**
+   * Lists the names of all tables in an instance asynchronously.
+   *
+   * @return a {@link ApiFuture} of type {@link Void} will be set when request is successful
+   *     otherwise exception will be thrown.
+   */
+  ApiFuture<List<String>> listTablesAsync();
+
+  /**
+   * Permanently deletes a specified table and all of its data.
+   *
+   * @return a {@link ApiFuture} of type {@link Void} will be set when request is successful
+   *     otherwise exception will be thrown.
+   */
+  ApiFuture<Void> deleteTableAsync(String tableId);
+
+  /**
+   * Creates, modifies or deletes a new column family within a specified table.
+   *
+   * @param request a {@link ModifyColumnFamiliesRequest} object.
+   * @return a {@link ApiFuture} that returns {@link Table} object that contains the updated table
+   *     structure.
+   */
+  ApiFuture<Table> modifyFamiliesAsync(ModifyColumnFamiliesRequest request);
+
+  /**
+   * Permanently deletes all rows in a range.
+   *
+   * @param tableId
+   * @param rowKeyPrefix
+   * @return a {@link ApiFuture} that returns {@link Void} object.
+   */
+  ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix);
+
+  /**
+   * Asynchronously drops all data in the table
+   *
+   * @param tableId a {@link String} object.
+   */
+  ApiFuture<Void> dropAllRowsAsync(String tableId);
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableConstants.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableConstants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers;
+
+import com.google.api.core.InternalApi;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+class BigtableConstants {
+
+  static final String BIGTABLE_DATA_HOST_DEFAULT = "bigtable.googleapis.com";
+
+  static final String BIGTABLE_ADMIN_HOST_DEFAULT = "bigtableadmin.googleapis.com";
+
+  static final int BIGTABLE_PORT_DEFAULT = 443;
+
+  static final int BIGTABLE_BULK_MAX_ROW_KEY_COUNT_DEFAULT = 125;
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableConstants.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableConstants.java
@@ -17,7 +17,6 @@ package com.google.cloud.bigtable.hbase.wrappers;
 
 import com.google.api.core.InternalApi;
 
-/** For internal use only - public for technical reasons. */
 @InternalApi("For internal usage only")
 class BigtableConstants {
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableHBaseSettings.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers;
+
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_ROW_KEY_COUNT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_PORT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_GCJ_CLIENT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INSTANCE_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.PROJECT_ID_KEY;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.config.Logger;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.wrappers.classic.BigtableHBaseClassicSettings;
+import com.google.cloud.bigtable.hbase.wrappers.veneer.BigtableHBaseVeneerSettings;
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public abstract class BigtableHBaseSettings {
+
+  protected static final Logger LOG = new Logger(BigtableOptionsFactory.class);
+
+  protected final Configuration configuration;
+  private final String projectId;
+  private final String instanceId;
+
+  public static BigtableHBaseSettings create(Configuration configuration) {
+    if (configuration.getBoolean(BIGTABLE_USE_GCJ_CLIENT, false)) {
+      return new BigtableHBaseVeneerSettings(configuration);
+    } else {
+      return new BigtableHBaseClassicSettings(configuration);
+    }
+  }
+
+  public BigtableHBaseSettings(Configuration configuration) {
+    this.configuration = configuration;
+    this.projectId = getValue(PROJECT_ID_KEY, "Project ID");
+    this.instanceId = getValue(INSTANCE_ID_KEY, "Instance ID");
+  }
+
+  public Configuration getConfiguration() {
+    return new Configuration(configuration);
+  }
+
+  public String getProjectId() {
+    return projectId;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  public String getDataHost() {
+    String hostNameStr = configuration.get(BIGTABLE_HOST_KEY);
+    return isNullOrEmpty(hostNameStr) ? BigtableConstants.BIGTABLE_DATA_HOST_DEFAULT : hostNameStr;
+  }
+
+  public String getAdminHost() {
+    String adminHostStr = configuration.get(BIGTABLE_ADMIN_HOST_KEY);
+    return isNullOrEmpty(adminHostStr)
+        ? BigtableConstants.BIGTABLE_ADMIN_HOST_DEFAULT
+        : adminHostStr;
+  }
+
+  public int getPort() {
+    String portNumberStr = configuration.get(BIGTABLE_PORT_KEY);
+    return isNullOrEmpty(portNumberStr)
+        ? BigtableConstants.BIGTABLE_PORT_DEFAULT
+        : Integer.valueOf(portNumberStr);
+  }
+
+  public int getBulkMaxRowCount() {
+    String bulkMaxRowKeyCountStr = configuration.get(BIGTABLE_BULK_MAX_ROW_KEY_COUNT);
+    return isNullOrEmpty(bulkMaxRowKeyCountStr)
+        ? BigtableConstants.BIGTABLE_BULK_MAX_ROW_KEY_COUNT_DEFAULT
+        : Integer.valueOf(bulkMaxRowKeyCountStr);
+  }
+
+  protected String getValue(String key, String type) {
+    String value = configuration.get(key);
+    Preconditions.checkArgument(
+        !isNullOrEmpty(value), String.format("%s must be supplied via %s", type, key));
+    return value;
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableWrapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers;
+
+import java.io.IOException;
+
+public abstract class BigtableWrapper {
+
+  private final BigtableHBaseSettings hBaseSettings;
+
+  public BigtableWrapper(BigtableHBaseSettings hbaseSettings) {
+    this.hBaseSettings = hbaseSettings;
+  }
+
+  public abstract AdminClientWrapper getAdminClientWrapper() throws IOException;
+
+  public abstract DataClientWrapper getDataClientWrapper();
+
+  public BigtableHBaseSettings getBigtableHBaseSettings() {
+    return hBaseSettings;
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkMutationWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkMutationWrapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import java.io.IOException;
+
+public interface BulkMutationWrapper extends AutoCloseable {
+
+  ApiFuture<Void> add(RowMutationEntry entry);
+
+  void sendUnsent();
+
+  void flush() throws InterruptedException;
+
+  void close() throws IOException;
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkReadWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkReadWrapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import java.io.IOException;
+import org.apache.hadoop.hbase.client.Result;
+
+public interface BulkReadWrapper extends AutoCloseable {
+
+  ApiFuture<Result> add(Query query);
+
+  void flush();
+
+  void close() throws IOException;
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/DataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/DataClientWrapper.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
+import com.google.cloud.bigtable.data.v2.models.KeyOffset;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
+import io.grpc.stub.StreamObserver;
+import java.util.List;
+import org.apache.hadoop.hbase.client.Result;
+
+public interface DataClientWrapper extends AutoCloseable {
+
+  BulkMutationWrapper createBulkMutationWrapper(String tableId);
+
+  BulkReadWrapper createBulkReadWrapper(String tableId);
+
+  /**
+   * Mutate a row atomically.
+   *
+   * @param rowMutation a {@link RowMutation} model object.
+   * @return a {@link ApiFuture} of type {@link Void} will be set when request is successful
+   *     otherwise exception will be thrown.
+   */
+  ApiFuture<Void> mutateRowsAsync(RowMutation rowMutation);
+
+  /**
+   * Perform an atomic read-modify-write operation on a row.
+   *
+   * @param readModifyWriteRow a {@link ReadModifyWriteRow} model object.
+   * @return a {@link ApiFuture} of type {@link Result} will be set when request is successful
+   *     otherwise exception will be thrown.
+   */
+  ApiFuture<Result> readModifyRowsAsync(ReadModifyWriteRow readModifyWriteRow);
+
+  /**
+   * Mutate a row atomically dependent on a precondition.
+   *
+   * @param conditionalRowMutation a {@link ConditionalRowMutation} model object.
+   * @return a {@link ApiFuture} of type {@link Boolean} will be set when request is successful
+   *     otherwise exception will be thrown.
+   */
+  ApiFuture<Boolean> checkAndMutateRowAsync(ConditionalRowMutation conditionalRowMutation);
+
+  /**
+   * Sample row keys from a table, returning a Future that will complete when the sampling has
+   * completed.
+   *
+   * @param tableId a String object.
+   * @return a {@link ApiFuture} object.
+   */
+  ApiFuture<List<KeyOffset>> sampleRowKeysAsync(String tableId);
+
+  /**
+   * Perform a scan over {@link Result}s, in key order.
+   *
+   * @param request a {@link Query} object.
+   * @return a {@link Result} object.
+   */
+  ResultScanner<Result> readRows(Query request);
+
+  /**
+   * Read multiple {@link Result}s into an in-memory list, in key order.
+   *
+   * @return a {@link ApiFuture} that will finish when all reads have completed.
+   * @param request a {@link Query} object.
+   */
+  ApiFuture<List<Result>> readRowsAsync(Query request);
+
+  /**
+   * Read {@link Result} asynchronously, and pass them to a stream observer to be processed.
+   *
+   * @param request a {@link Query} object.
+   * @param observer a {@link StreamObserver} object.
+   */
+  void readRowsAsync(Query request, StreamObserver<Result> observer);
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.classic;
+
+import static com.google.cloud.bigtable.config.BulkOptions.BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT;
+import static com.google.cloud.bigtable.config.BulkOptions.BIGTABLE_BULK_AUTOFLUSH_MS_DEFAULT;
+import static com.google.cloud.bigtable.config.BulkOptions.BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES_DEFAULT;
+import static com.google.cloud.bigtable.config.BulkOptions.BIGTABLE_BULK_MAX_ROW_KEY_COUNT_DEFAULT;
+import static com.google.cloud.bigtable.config.BulkOptions.BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT;
+import static com.google.cloud.bigtable.config.CallOptionsConfig.LONG_TIMEOUT_MS_DEFAULT;
+import static com.google.cloud.bigtable.config.CallOptionsConfig.SHORT_TIMEOUT_MS_DEFAULT;
+import static com.google.cloud.bigtable.config.CallOptionsConfig.USE_TIMEOUT_DEFAULT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ADDITIONAL_RETRY_CODES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ALLOW_NO_TIMESTAMP_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.APP_PROFILE_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_ASYNC_MUTATOR_COUNT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_AUTOFLUSH_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_ROW_KEY_COUNT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_LONG_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_MUTATE_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_DEFAULT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_READ_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_P12_KEYFILE_LOCATION_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_BATCH;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_BULK_API;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_GCJ_CLIENT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_DEFAULT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_TIMEOUTS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ENABLE_GRPC_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ENABLE_GRPC_RETRY_DEADLINEEXCEEDED_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INITIAL_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INSTANCE_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_INFLIGHT_RPCS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_SCAN_TIMEOUT_RETRIES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.PROJECT_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.READ_BUFFER_SIZE;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.READ_PARTIAL_ROW_TIMEOUT_MS;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import com.google.api.core.InternalApi;
+import com.google.auth.Credentials;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.BulkOptions;
+import com.google.cloud.bigtable.config.CallOptionsConfig;
+import com.google.cloud.bigtable.config.CredentialOptions;
+import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.hbase.BigtableExtendedConfiguration;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.common.base.Preconditions;
+import io.grpc.Status;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.util.VersionInfo;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public class BigtableHBaseClassicSettings extends BigtableHBaseSettings {
+
+  public BigtableHBaseClassicSettings(Configuration configuration) {
+    super(configuration);
+  }
+
+  // <editor-fold desc="Public API">
+  /** For internal use only - public for technical reasons. */
+  @InternalApi("For internal usage only")
+  public BigtableOptions getBigtableOptions() throws IOException {
+    BigtableOptions.Builder bigtableOptionsBuilder = BigtableOptions.builder();
+
+    bigtableOptionsBuilder.setProjectId(getValue(PROJECT_ID_KEY, "Project " + "ID"));
+    bigtableOptionsBuilder.setInstanceId(getValue(INSTANCE_ID_KEY, "Instance ID"));
+    String appProfileId = configuration.get(APP_PROFILE_ID_KEY);
+
+    if (appProfileId != null) {
+      bigtableOptionsBuilder.setAppProfileId(appProfileId);
+    }
+
+    String dataHostOverride = configuration.get(BIGTABLE_HOST_KEY);
+    if (dataHostOverride != null) {
+      LOG.debug("API Data endpoint host %s.", dataHostOverride);
+      bigtableOptionsBuilder.setDataHost(dataHostOverride);
+    }
+
+    String adminHostOverride = configuration.get(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY);
+    if (adminHostOverride != null) {
+      LOG.debug("Admin endpoint host %s.", adminHostOverride);
+      bigtableOptionsBuilder.setAdminHost(adminHostOverride);
+    }
+
+    String portOverrideStr = configuration.get(BigtableOptionsFactory.BIGTABLE_PORT_KEY);
+    if (portOverrideStr != null) {
+      bigtableOptionsBuilder.setPort(Integer.parseInt(portOverrideStr));
+    }
+
+    String usePlaintextStr = configuration.get(BIGTABLE_USE_PLAINTEXT_NEGOTIATION);
+    if (usePlaintextStr != null) {
+      bigtableOptionsBuilder.setUsePlaintextNegotiation(Boolean.parseBoolean(usePlaintextStr));
+    }
+
+    setBulkOptions(bigtableOptionsBuilder);
+    setChannelOptions(bigtableOptionsBuilder);
+    setClientCallOptions(bigtableOptionsBuilder);
+
+    String emulatorHost = configuration.get(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY);
+    if (emulatorHost != null) {
+      bigtableOptionsBuilder.enableEmulator(emulatorHost);
+    }
+
+    String useBatchStr = configuration.get(BIGTABLE_USE_BATCH);
+    if (useBatchStr != null) {
+      bigtableOptionsBuilder.setUseBatch(Boolean.parseBoolean(useBatchStr));
+    }
+
+    String useGcjClientStr = configuration.get(BIGTABLE_USE_GCJ_CLIENT);
+    if (useGcjClientStr != null) {
+      bigtableOptionsBuilder.setUseGCJClient(Boolean.parseBoolean(useGcjClientStr));
+    }
+    return bigtableOptionsBuilder.build();
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="Private Helpers">
+  private void setChannelOptions(BigtableOptions.Builder builder) throws IOException {
+    setCredentialOptions(builder);
+
+    builder.setRetryOptions(createRetryOptions());
+
+    String channelCountStr = configuration.get(BIGTABLE_DATA_CHANNEL_COUNT_KEY);
+    if (channelCountStr != null) {
+      builder.setDataChannelCount(Integer.parseInt(channelCountStr));
+    }
+
+    // This is primarily used by Dataflow where connections open and close often. This is a
+    // performance optimization that will reduce the cost to open connections.
+    String useCachedDataPoolStr = configuration.get(BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL);
+    if (useCachedDataPoolStr != null) {
+      builder.setUseCachedDataPool(Boolean.parseBoolean(useCachedDataPoolStr));
+    }
+
+    // This information is in addition to bigtable-client-core version, and jdk version.
+    StringBuilder agentBuilder = new StringBuilder();
+    agentBuilder.append("hbase-").append(VersionInfo.getVersion());
+    String customUserAgent = configuration.get(CUSTOM_USER_AGENT_KEY);
+    if (customUserAgent != null) {
+      agentBuilder.append(',').append(customUserAgent);
+    }
+    builder.setUserAgent(agentBuilder.toString());
+  }
+
+  private void setBulkOptions(BigtableOptions.Builder bigtableOptionsBuilder) {
+    BulkOptions.Builder bulkOptionsBuilder = BulkOptions.builder();
+
+    int asyncMutatorCount =
+        configuration.getInt(
+            BIGTABLE_ASYNC_MUTATOR_COUNT_KEY, BIGTABLE_ASYNC_MUTATOR_COUNT_DEFAULT);
+    bulkOptionsBuilder.setAsyncMutatorWorkerCount(asyncMutatorCount);
+
+    bulkOptionsBuilder.setUseBulkApi(configuration.getBoolean(BIGTABLE_USE_BULK_API, true));
+    bulkOptionsBuilder.setBulkMaxRowKeyCount(
+        configuration.getInt(
+            BIGTABLE_BULK_MAX_ROW_KEY_COUNT, BIGTABLE_BULK_MAX_ROW_KEY_COUNT_DEFAULT));
+    bulkOptionsBuilder.setBulkMaxRequestSize(
+        configuration.getLong(
+            BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES, BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES_DEFAULT));
+    bulkOptionsBuilder.setAutoflushMs(
+        configuration.getLong(BIGTABLE_BULK_AUTOFLUSH_MS_KEY, BIGTABLE_BULK_AUTOFLUSH_MS_DEFAULT));
+
+    int defaultRpcCount =
+        BIGTABLE_MAX_INFLIGHT_RPCS_PER_CHANNEL_DEFAULT
+            * bigtableOptionsBuilder.getDataChannelCount();
+    int maxInflightRpcs = configuration.getInt(MAX_INFLIGHT_RPCS_KEY, defaultRpcCount);
+    bulkOptionsBuilder.setMaxInflightRpcs(maxInflightRpcs);
+
+    long maxMemory =
+        configuration.getLong(
+            BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY, BulkOptions.BIGTABLE_MAX_MEMORY_DEFAULT);
+    bulkOptionsBuilder.setMaxMemory(maxMemory);
+
+    if (configuration.getBoolean(
+        BIGTABLE_BUFFERED_MUTATOR_ENABLE_THROTTLING,
+        BulkOptions.BIGTABLE_BULK_ENABLE_THROTTLE_REBALANCE_DEFAULT)) {
+      LOG.info(
+          "Bigtable mutation latency throttling enabled with threshold %d",
+          configuration.getInt(
+              BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS,
+              BulkOptions.BIGTABLE_BULK_THROTTLE_TARGET_MS_DEFAULT));
+      bulkOptionsBuilder.enableBulkMutationThrottling();
+      bulkOptionsBuilder.setBulkMutationRpcTargetMs(
+          configuration.getInt(
+              BIGTABLE_BUFFERED_MUTATOR_THROTTLING_THRESHOLD_MILLIS,
+              BulkOptions.BIGTABLE_BULK_THROTTLE_TARGET_MS_DEFAULT));
+    }
+
+    bigtableOptionsBuilder.setBulkOptions(bulkOptionsBuilder.build());
+  }
+
+  private void setCredentialOptions(BigtableOptions.Builder builder) throws FileNotFoundException {
+    if (configuration.getBoolean(
+        BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, BIGTABLE_USE_SERVICE_ACCOUNTS_DEFAULT)) {
+      LOG.debug("Using service accounts");
+
+      if (configuration instanceof BigtableExtendedConfiguration) {
+        Credentials credentials = ((BigtableExtendedConfiguration) configuration).getCredentials();
+        builder.setCredentialOptions(CredentialOptions.credential(credentials));
+      } else if (configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY) != null) {
+        String jsonValue = configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY);
+        LOG.debug("Using json value");
+        builder.setCredentialOptions(CredentialOptions.jsonCredentials(jsonValue));
+      } else if (configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY) != null) {
+        String keyFileLocation =
+            configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY);
+        LOG.debug("Using json keyfile: %s", keyFileLocation);
+        builder.setCredentialOptions(
+            CredentialOptions.jsonCredentials(new FileInputStream(keyFileLocation)));
+      } else if (configuration.get(BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY) != null) {
+        String serviceAccount = configuration.get(BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY);
+        LOG.debug("Service account %s specified.", serviceAccount);
+        String keyFileLocation =
+            configuration.get(BIGTABLE_SERVICE_ACCOUNT_P12_KEYFILE_LOCATION_KEY);
+        Preconditions.checkState(
+            !isNullOrEmpty(keyFileLocation),
+            "Key file location must be specified when setting service account email");
+        LOG.debug("Using p12 keyfile: %s", keyFileLocation);
+        builder.setCredentialOptions(
+            CredentialOptions.p12Credential(serviceAccount, keyFileLocation));
+      } else {
+        LOG.debug("Using default credentials.");
+        builder.setCredentialOptions(CredentialOptions.defaultCredentials());
+      }
+    } else if (configuration.getBoolean(
+        BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, BIGTABLE_NULL_CREDENTIAL_ENABLE_DEFAULT)) {
+      builder.setCredentialOptions(CredentialOptions.nullCredential());
+      LOG.info("Enabling the use of null credentials. This should not be used in production.");
+    } else {
+      throw new IllegalStateException("Either service account or null credentials must be enabled");
+    }
+  }
+
+  private void setClientCallOptions(BigtableOptions.Builder bigtableOptionsBuilder) {
+    CallOptionsConfig.Builder clientCallOptionsBuilder = CallOptionsConfig.builder();
+
+    clientCallOptionsBuilder.setUseTimeout(
+        configuration.getBoolean(BIGTABLE_USE_TIMEOUTS_KEY, USE_TIMEOUT_DEFAULT));
+    clientCallOptionsBuilder.setShortRpcTimeoutMs(
+        configuration.getInt(BIGTABLE_RPC_TIMEOUT_MS_KEY, SHORT_TIMEOUT_MS_DEFAULT));
+    int longTimeoutMs =
+        configuration.getInt(BIGTABLE_LONG_RPC_TIMEOUT_MS_KEY, LONG_TIMEOUT_MS_DEFAULT);
+    clientCallOptionsBuilder.setMutateRpcTimeoutMs(
+        configuration.getInt(BIGTABLE_MUTATE_RPC_TIMEOUT_MS_KEY, longTimeoutMs));
+    clientCallOptionsBuilder.setReadRowsRpcTimeoutMs(
+        configuration.getInt(BIGTABLE_READ_RPC_TIMEOUT_MS_KEY, longTimeoutMs));
+    bigtableOptionsBuilder.setCallOptionsConfig(clientCallOptionsBuilder.build());
+  }
+
+  private RetryOptions createRetryOptions() {
+    RetryOptions.Builder retryOptionsBuilder = RetryOptions.builder();
+    boolean enableRetries =
+        configuration.getBoolean(ENABLE_GRPC_RETRIES_KEY, RetryOptions.DEFAULT_ENABLE_GRPC_RETRIES);
+    LOG.debug("gRPC retries enabled: %s", enableRetries);
+    retryOptionsBuilder.setEnableRetries(enableRetries);
+
+    boolean allowRetriesWithoutTimestamp =
+        configuration.getBoolean(ALLOW_NO_TIMESTAMP_RETRIES_KEY, false);
+    LOG.debug("allow retries without timestamp: %s", enableRetries);
+    retryOptionsBuilder.setAllowRetriesWithoutTimestamp(allowRetriesWithoutTimestamp);
+
+    String retryCodes = configuration.get(ADDITIONAL_RETRY_CODES, "");
+    String codes[] = retryCodes.split(",");
+    for (String stringCode : codes) {
+      String trimmed = stringCode.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+      Status.Code code = Status.Code.valueOf(trimmed);
+      Preconditions.checkArgument(code != null, "Code " + stringCode + " not found.");
+      LOG.debug("gRPC retry on: %s", stringCode);
+      retryOptionsBuilder.addStatusToRetryOn(code);
+    }
+
+    boolean retryOnDeadlineExceeded =
+        configuration.getBoolean(ENABLE_GRPC_RETRY_DEADLINEEXCEEDED_KEY, true);
+    LOG.debug("gRPC retry on deadline exceeded enabled: %s", retryOnDeadlineExceeded);
+    retryOptionsBuilder.setRetryOnDeadlineExceeded(retryOnDeadlineExceeded);
+
+    int initialElapsedBackoffMillis =
+        configuration.getInt(
+            INITIAL_ELAPSED_BACKOFF_MILLIS_KEY, RetryOptions.DEFAULT_INITIAL_BACKOFF_MILLIS);
+    LOG.debug("gRPC retry initialElapsedBackoffMillis: %d", initialElapsedBackoffMillis);
+    retryOptionsBuilder.setInitialBackoffMillis(initialElapsedBackoffMillis);
+
+    int maxElapsedBackoffMillis =
+        configuration.getInt(
+            MAX_ELAPSED_BACKOFF_MILLIS_KEY, RetryOptions.DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS);
+    LOG.debug("gRPC retry maxElapsedBackoffMillis: %d", maxElapsedBackoffMillis);
+    retryOptionsBuilder.setMaxElapsedBackoffMillis(maxElapsedBackoffMillis);
+
+    int readPartialRowTimeoutMillis =
+        configuration.getInt(
+            READ_PARTIAL_ROW_TIMEOUT_MS, RetryOptions.DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS);
+    LOG.debug("gRPC read partial row timeout (millis): %d", readPartialRowTimeoutMillis);
+    retryOptionsBuilder.setReadPartialRowTimeoutMillis(readPartialRowTimeoutMillis);
+
+    int streamingBufferSize =
+        configuration.getInt(READ_BUFFER_SIZE, RetryOptions.DEFAULT_STREAMING_BUFFER_SIZE);
+    LOG.debug("gRPC read buffer size (count): %d", streamingBufferSize);
+    retryOptionsBuilder.setStreamingBufferSize(streamingBufferSize);
+
+    int maxScanTimeoutRetries =
+        configuration.getInt(
+            MAX_SCAN_TIMEOUT_RETRIES, RetryOptions.DEFAULT_MAX_SCAN_TIMEOUT_RETRIES);
+    LOG.debug("gRPC max scan timeout retries (count): %d", maxScanTimeoutRetries);
+    retryOptionsBuilder.setMaxScanTimeoutRetries(maxScanTimeoutRetries);
+
+    return retryOptionsBuilder.build();
+  }
+  // </editor-fold>
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableHBaseClassicSettings.java
@@ -296,7 +296,7 @@ public class BigtableHBaseClassicSettings extends BigtableHBaseSettings {
     retryOptionsBuilder.setAllowRetriesWithoutTimestamp(allowRetriesWithoutTimestamp);
 
     String retryCodes = configuration.get(ADDITIONAL_RETRY_CODES, "");
-    String codes[] = retryCodes.split(",");
+    String[] codes = retryCodes.split(",");
     for (String stringCode : codes) {
       String trimmed = stringCode.trim();
       if (trimmed.isEmpty()) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/AdminClientVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/AdminClientVeneerApi.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.api.core.ApiFuture;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
+import com.google.cloud.bigtable.admin.v2.models.Table;
+import com.google.cloud.bigtable.hbase.wrappers.AdminClientWrapper;
+import java.util.List;
+
+public class AdminClientVeneerApi implements AdminClientWrapper {
+
+  private final BigtableTableAdminClient delegate;
+
+  AdminClientVeneerApi(BigtableTableAdminClient delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public ApiFuture<Table> createTableAsync(CreateTableRequest request) {
+    return delegate.createTableAsync(request);
+  }
+
+  @Override
+  public ApiFuture<Table> getTableAsync(String tableId) {
+    return delegate.getTableAsync(tableId);
+  }
+
+  @Override
+  public ApiFuture<List<String>> listTablesAsync() {
+    return delegate.listTablesAsync();
+  }
+
+  @Override
+  public ApiFuture<Void> deleteTableAsync(String tableId) {
+    return delegate.deleteTableAsync(tableId);
+  }
+
+  @Override
+  public ApiFuture<Table> modifyFamiliesAsync(ModifyColumnFamiliesRequest request) {
+    return delegate.modifyFamiliesAsync(request);
+  }
+
+  @Override
+  public ApiFuture<Void> dropRowRangeAsync(String tableId, String rowKeyPrefix) {
+    return delegate.dropRowRangeAsync(tableId, rowKeyPrefix);
+  }
+
+  @Override
+  public ApiFuture<Void> dropAllRowsAsync(String tableId) {
+    return delegate.dropAllRowsAsync(tableId);
+  }
+
+  @Override
+  public void close() throws Exception {
+    delegate.close();
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
@@ -1,0 +1,554 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import static com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings.defaultGrpcTransportProviderBuilder;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ADDITIONAL_RETRY_CODES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ALLOW_NO_TIMESTAMP_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.APP_PROFILE_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_AUTOFLUSH_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_ROW_KEY_COUNT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_READ_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_SERVICE_ACCOUNT_P12_KEYFILE_LOCATION_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_TIMEOUTS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ENABLE_GRPC_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INITIAL_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_INFLIGHT_RPCS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_SCAN_TIMEOUT_RETRIES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.PROJECT_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.READ_PARTIAL_ROW_TIMEOUT_MS;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.grpc.internal.GrpcUtil.USER_AGENT_KEY;
+import static org.threeten.bp.Duration.ofMillis;
+
+import com.google.api.client.util.SecurityUtils;
+import com.google.api.core.ApiFunction;
+import com.google.api.core.InternalApi;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.FlowControlSettings;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.api.gax.rpc.FixedHeaderProvider;
+import com.google.api.gax.rpc.HeaderProvider;
+import com.google.api.gax.rpc.StatusCode;
+import com.google.api.gax.rpc.TransportChannelProvider;
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.ServiceAccountJwtAccessCredentials;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.cloud.bigtable.admin.v2.stub.BigtableTableAdminStubSettings;
+import com.google.cloud.bigtable.config.BigtableVersionInfo;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.stub.EnhancedBigtableStubSettings;
+import com.google.cloud.bigtable.hbase.BigtableExtendedConfiguration;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Status;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.util.VersionInfo;
+import org.threeten.bp.Duration;
+
+/** For internal use only - public for technical reasons. */
+@InternalApi("For internal usage only")
+public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
+
+  // Identifier to distinguish between CBT or GCJ adapter.
+  private static final String VENEER_ADAPTER =
+      BigtableVersionInfo.CORE_USER_AGENT + "," + "veneer-adapter,";
+
+  public BigtableHBaseVeneerSettings(Configuration configuration) {
+    super(configuration);
+  }
+
+  @InternalApi
+  public boolean isChannelPoolCachingEnabled() {
+    // This is primarily used by Dataflow where connections open and close often. This is a
+    // performance optimization that will reduce the cost to open connections.
+    return configuration.getBoolean(BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL, false);
+  }
+
+  // <editor-fold desc="Public Utility">
+  /**
+   * Utility to convert {@link Configuration} to {@link BigtableDataSettings}.
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
+  public BigtableDataSettings getDataSettings() throws IOException {
+    BigtableDataSettings.Builder dataBuilder = BigtableDataSettings.newBuilder();
+    EnhancedBigtableStubSettings.Builder stubSettings = dataBuilder.stubSettings();
+
+    dataBuilder.setProjectId(getProjectId()).setInstanceId(getInstanceId());
+
+    String appProfileId = configuration.get(APP_PROFILE_ID_KEY);
+    if (!isNullOrEmpty(appProfileId)) {
+      dataBuilder.setAppProfileId(appProfileId);
+    }
+
+    String dataHostOverride = configuration.get(BIGTABLE_HOST_KEY);
+    if (!isNullOrEmpty(dataHostOverride)) {
+      String endpoint = dataHostOverride + ":" + getPort();
+      LOG.debug("API Data endpoint hostname:portNumber is %s", endpoint);
+
+      stubSettings.setEndpoint(endpoint);
+    }
+
+    stubSettings.setHeaderProvider(buildHeaderProvider());
+
+    if (Boolean.parseBoolean(configuration.get(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY))) {
+      CredentialsProvider credentialsProvider = buildCredentialProvider();
+      if (credentialsProvider != null) {
+        stubSettings.setCredentialsProvider(credentialsProvider);
+      }
+    } else if (Boolean.parseBoolean(configuration.get(BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY))) {
+      stubSettings.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    if (configuration.getBoolean(BIGTABLE_USE_PLAINTEXT_NEGOTIATION, false)) {
+      stubSettings.setTransportChannelProvider(
+          buildPlainTextChannelProvider(stubSettings.getEndpoint()));
+    }
+
+    String shortRpcTimeoutStr = configuration.get(BIGTABLE_RPC_TIMEOUT_MS_KEY);
+    if (shortRpcTimeoutStr != null) {
+      // rpcTimeout & totalTimeout for non-retry operations.
+      Duration shortRpcTimeout = ofMillis(Long.valueOf(shortRpcTimeoutStr));
+
+      stubSettings.checkAndMutateRowSettings().setSimpleTimeoutNoRetries(shortRpcTimeout);
+
+      stubSettings.readModifyWriteRowSettings().setSimpleTimeoutNoRetries(shortRpcTimeout);
+    }
+
+    buildBulkMutationsSettings(stubSettings);
+
+    buildBulkReadRowsSettings(stubSettings);
+
+    buildReadRowsSettings(stubSettings);
+
+    stubSettings
+        .readRowSettings()
+        .setRetryableCodes(buildRetryCodes(stubSettings.readRowSettings().getRetryableCodes()))
+        .setRetrySettings(
+            buildIdempotentRetrySettings(stubSettings.readRowSettings().getRetrySettings()));
+
+    stubSettings
+        .mutateRowSettings()
+        .setRetryableCodes(buildRetryCodes(stubSettings.mutateRowSettings().getRetryableCodes()))
+        .setRetrySettings(
+            buildIdempotentRetrySettings(stubSettings.mutateRowSettings().getRetrySettings()));
+
+    stubSettings
+        .sampleRowKeysSettings()
+        .setRetryableCodes(
+            buildRetryCodes(stubSettings.sampleRowKeysSettings().getRetryableCodes()))
+        .setRetrySettings(
+            buildIdempotentRetrySettings(stubSettings.sampleRowKeysSettings().getRetrySettings()));
+
+    String emulatorHostPort = configuration.get(BIGTABLE_EMULATOR_HOST_KEY);
+    if (!isNullOrEmpty(emulatorHostPort)) {
+      stubSettings
+          .setCredentialsProvider(NoCredentialsProvider.create())
+          .setEndpoint(emulatorHostPort)
+          .setTransportChannelProvider(buildPlainTextChannelProvider(emulatorHostPort));
+    }
+
+    return dataBuilder.build();
+  }
+
+  /**
+   * Utility to convert {@link Configuration} to {@link BigtableTableAdminSettings}.
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
+  public BigtableTableAdminSettings getTableAdminSettings() throws IOException {
+    BigtableTableAdminSettings.Builder adminBuilder = BigtableTableAdminSettings.newBuilder();
+    BigtableTableAdminStubSettings.Builder stubSettings = adminBuilder.stubSettings();
+
+    adminBuilder.setProjectId(getProjectId()).setInstanceId(getInstanceId());
+
+    String adminHostOverride = configuration.get(BIGTABLE_ADMIN_HOST_KEY);
+    if (!isNullOrEmpty(adminHostOverride)) {
+      String endpoint = adminHostOverride + ":" + getPort();
+      LOG.debug("Admin endpoint host:port is %s.", endpoint);
+
+      stubSettings.setEndpoint(endpoint);
+    }
+
+    stubSettings.setHeaderProvider(buildHeaderProvider());
+
+    if (Boolean.parseBoolean(configuration.get(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY))) {
+      CredentialsProvider credentialsProvider = buildCredentialProvider();
+      if (credentialsProvider != null) {
+        stubSettings.setCredentialsProvider(credentialsProvider);
+      }
+    } else if (Boolean.parseBoolean(configuration.get(BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY))) {
+      stubSettings.setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    if (Boolean.parseBoolean(configuration.get(BIGTABLE_USE_PLAINTEXT_NEGOTIATION))) {
+      stubSettings.setTransportChannelProvider(
+          buildPlainTextChannelProvider(stubSettings.getEndpoint()));
+    }
+
+    String emulatorHostPort = configuration.get(BIGTABLE_EMULATOR_HOST_KEY);
+    if (!isNullOrEmpty(emulatorHostPort)) {
+      stubSettings
+          .setCredentialsProvider(NoCredentialsProvider.create())
+          .setEndpoint(emulatorHostPort)
+          .setTransportChannelProvider(buildPlainTextChannelProvider(emulatorHostPort));
+    }
+
+    return adminBuilder.build();
+  }
+
+  /**
+   * Utility to convert {@link Configuration} to {@link BigtableInstanceAdminSettings}.
+   *
+   * <p>For internal use only - public for technical reasons.
+   */
+  @InternalApi("For internal usage only")
+  public BigtableInstanceAdminSettings getInstanceAdminSettings() throws IOException {
+    Preconditions.checkState(
+        isNullOrEmpty(configuration.get(BIGTABLE_EMULATOR_HOST_KEY)),
+        "Instance admin does not support emulator");
+
+    BigtableInstanceAdminSettings.Builder builder = BigtableInstanceAdminSettings.newBuilder();
+
+    builder.setProjectId(getValue(PROJECT_ID_KEY, "Project ID"));
+
+    String adminHostOverride = configuration.get(BIGTABLE_ADMIN_HOST_KEY);
+    String endpoint = adminHostOverride + ":" + getPort();
+    LOG.debug("Instance Admin endpoint host:port is %s.", endpoint);
+
+    builder.stubSettings().setHeaderProvider(buildHeaderProvider());
+
+    if (Boolean.parseBoolean(configuration.get(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY))) {
+      CredentialsProvider credentialsProvider = buildCredentialProvider();
+      if (credentialsProvider != null) {
+        builder.stubSettings().setCredentialsProvider(credentialsProvider);
+      }
+    } else if (Boolean.parseBoolean(configuration.get(BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY))) {
+      builder.stubSettings().setCredentialsProvider(NoCredentialsProvider.create());
+    }
+
+    return builder.build();
+  }
+  // </editor-fold>
+
+  // <editor-fold desc="Private Helpers">
+  /** Creates {@link HeaderProvider} with VENEER_ADAPTER as prefix for user agent */
+  private HeaderProvider buildHeaderProvider() {
+
+    // This information is in addition to bigtable-client-core version, and jdk version.
+    StringBuilder agentBuilder = new StringBuilder();
+    agentBuilder.append("hbase-").append(VersionInfo.getVersion());
+    String customUserAgent = configuration.get(CUSTOM_USER_AGENT_KEY);
+    if (customUserAgent != null) {
+      agentBuilder.append(',').append(customUserAgent);
+    }
+
+    return FixedHeaderProvider.create(
+        USER_AGENT_KEY.name(), VENEER_ADAPTER + agentBuilder.toString());
+  }
+
+  private CredentialsProvider buildCredentialProvider() throws IOException {
+    Credentials credentials = null;
+    LOG.debug("Using service accounts");
+
+    if (configuration instanceof BigtableExtendedConfiguration) {
+
+      credentials = ((BigtableExtendedConfiguration) configuration).getCredentials();
+
+    } else if (!isNullOrEmpty(configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY))) {
+
+      String jsonValue = configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_VALUE_KEY);
+      LOG.debug("Using json value");
+
+      Preconditions.checkState(
+          !isNullOrEmpty(jsonValue), "service account json value is null or empty");
+      credentials =
+          GoogleCredentials.fromStream(
+              new ByteArrayInputStream(jsonValue.getBytes(StandardCharsets.UTF_8)));
+
+    } else if (!isNullOrEmpty(
+        configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY))) {
+
+      String keyFileLocation =
+          configuration.get(BIGTABLE_SERVICE_ACCOUNT_JSON_KEYFILE_LOCATION_KEY);
+      LOG.debug("Using json keyfile: %s", keyFileLocation);
+
+      Preconditions.checkState(
+          !isNullOrEmpty(keyFileLocation), "service account location is null or empty");
+      credentials = GoogleCredentials.fromStream(new FileInputStream(keyFileLocation));
+
+    } else if (!isNullOrEmpty(configuration.get(BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY))) {
+
+      String serviceAccount = configuration.get(BIGTABLE_SERVICE_ACCOUNT_EMAIL_KEY);
+      LOG.debug("Service account %s specified.", serviceAccount);
+
+      String keyFileLocation = configuration.get(BIGTABLE_SERVICE_ACCOUNT_P12_KEYFILE_LOCATION_KEY);
+      Preconditions.checkState(
+          !isNullOrEmpty(keyFileLocation),
+          "Key file location must be specified when setting service account email");
+      LOG.debug("Using p12 keyfile: %s", keyFileLocation);
+
+      credentials = getCredentialFromPrivateKeyServiceAccount(serviceAccount, keyFileLocation);
+    } else {
+
+      LOG.debug("No credentials found with service account");
+      return null;
+    }
+
+    return FixedCredentialsProvider.create(credentials);
+  }
+
+  // copied over from CredentialFactory
+  // TODO: Find a better way to convert P12 key into Credentials instance
+  private Credentials getCredentialFromPrivateKeyServiceAccount(
+      String serviceAccountEmail, String privateKeyFile) throws IOException {
+    try {
+      PrivateKey privateKey =
+          SecurityUtils.loadPrivateKeyFromKeyStore(
+              SecurityUtils.getPkcs12KeyStore(),
+              new FileInputStream(privateKeyFile),
+              "notasecret",
+              "privatekey",
+              "notasecret");
+
+      return ServiceAccountJwtAccessCredentials.newBuilder()
+          .setClientEmail(serviceAccountEmail)
+          .setPrivateKey(privateKey)
+          .build();
+    } catch (GeneralSecurityException exception) {
+      throw new RuntimeException("exception while retrieving credentials", exception);
+    }
+  }
+
+  /** Creates {@link TransportChannelProvider} for plaintext negotiation type. */
+  private TransportChannelProvider buildPlainTextChannelProvider(String endpoint) {
+
+    InstantiatingGrpcChannelProvider.Builder channelBuilder =
+        defaultGrpcTransportProviderBuilder()
+            .setEndpoint(endpoint)
+            .setChannelConfigurator(
+                new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
+                  @Override
+                  public ManagedChannelBuilder apply(ManagedChannelBuilder channelBuilder) {
+                    return channelBuilder.usePlaintext();
+                  }
+                });
+
+    String channelCount = configuration.get(BIGTABLE_DATA_CHANNEL_COUNT_KEY);
+    if (!isNullOrEmpty(channelCount)) {
+      channelBuilder.setPoolSize(Integer.parseInt(channelCount));
+    }
+
+    return channelBuilder.build();
+  }
+
+  /** Creates {@link Set} of {@link StatusCode.Code} from {@link Status.Code} */
+  private Set<StatusCode.Code> buildRetryCodes(Set<StatusCode.Code> retryableCodes) {
+    ImmutableSet.Builder<StatusCode.Code> statusCodeBuilder = ImmutableSet.builder();
+
+    // Disables retries for all data operations
+    if (!configuration.getBoolean(ENABLE_GRPC_RETRIES_KEY, true)) {
+      return statusCodeBuilder.build();
+    }
+
+    statusCodeBuilder.addAll(retryableCodes);
+
+    String retryCodes = configuration.get(ADDITIONAL_RETRY_CODES, "");
+
+    for (String stringCode : retryCodes.split(",")) {
+      String trimmed = stringCode.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+
+      StatusCode.Code code = StatusCode.Code.valueOf(trimmed);
+
+      Preconditions.checkNotNull(code, String.format("Unknown status code %s found", stringCode));
+      statusCodeBuilder.add(code);
+      LOG.debug("gRPC retry on: %s", stringCode);
+    }
+
+    return statusCodeBuilder.build();
+  }
+
+  /** Creates {@link RetrySettings} for non-streaming VENEER_ADAPTER method. */
+  private RetrySettings buildIdempotentRetrySettings(RetrySettings originalRetrySettings) {
+    RetrySettings.Builder retryBuilder = originalRetrySettings.toBuilder();
+
+    if (configuration.getBoolean(ALLOW_NO_TIMESTAMP_RETRIES_KEY, false)) {
+      throw new UnsupportedOperationException("Retries without Timestamp is not supported yet.");
+    }
+
+    String initialElapsedBackoffMsStr = configuration.get(INITIAL_ELAPSED_BACKOFF_MILLIS_KEY);
+    if (!isNullOrEmpty(initialElapsedBackoffMsStr)) {
+      retryBuilder.setInitialRetryDelay(ofMillis(Long.parseLong(initialElapsedBackoffMsStr)));
+    }
+
+    if (Boolean.parseBoolean(configuration.get(BIGTABLE_USE_TIMEOUTS_KEY))) {
+      String shortRpcTimeoutMsStr = configuration.get(BIGTABLE_RPC_TIMEOUT_MS_KEY);
+
+      if (!isNullOrEmpty(shortRpcTimeoutMsStr)) {
+        Duration rpcTimeoutMs = ofMillis(Long.valueOf(shortRpcTimeoutMsStr));
+        retryBuilder.setInitialRpcTimeout(rpcTimeoutMs).setMaxRpcTimeout(rpcTimeoutMs);
+      }
+    }
+
+    String maxElapsedBackoffMillis = configuration.get(MAX_ELAPSED_BACKOFF_MILLIS_KEY);
+    if (!isNullOrEmpty(maxElapsedBackoffMillis)) {
+      retryBuilder.setTotalTimeout(ofMillis(Long.valueOf(maxElapsedBackoffMillis)));
+    }
+
+    return retryBuilder.build();
+  }
+
+  private void buildBulkMutationsSettings(EnhancedBigtableStubSettings.Builder builder) {
+    BatchingSettings.Builder batchMutateBuilder =
+        builder.bulkMutateRowsSettings().getBatchingSettings().toBuilder();
+
+    String autoFlushStr = configuration.get(BIGTABLE_BULK_AUTOFLUSH_MS_KEY);
+    if (autoFlushStr != null) {
+      long autoFlushMs = Long.valueOf(autoFlushStr);
+      if (autoFlushMs > 0) {
+        batchMutateBuilder.setDelayThreshold(ofMillis(autoFlushMs));
+      }
+    }
+
+    long bulkMaxRowKeyCount = getBulkMaxRowCount();
+    batchMutateBuilder.setElementCountThreshold(bulkMaxRowKeyCount);
+
+    String maxInflightRpcStr = configuration.get(MAX_INFLIGHT_RPCS_KEY);
+    if (!isNullOrEmpty(maxInflightRpcStr) && Integer.parseInt(maxInflightRpcStr) > 0) {
+
+      int maxInflightRpcCount = Integer.parseInt(maxInflightRpcStr);
+      FlowControlSettings.Builder flowControlBuilder =
+          FlowControlSettings.newBuilder()
+              // TODO: verify if it should be channelCount instead of maxRowKeyCount
+              .setMaxOutstandingElementCount(maxInflightRpcCount * bulkMaxRowKeyCount);
+
+      String maxMemory = configuration.get(BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY);
+      if (!isNullOrEmpty(maxMemory)) {
+        flowControlBuilder.setMaxOutstandingRequestBytes(Long.valueOf(maxMemory));
+      }
+
+      batchMutateBuilder.setFlowControlSettings(flowControlBuilder.build());
+    }
+
+    String requestByteThresholdStr = configuration.get(BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES);
+    if (!isNullOrEmpty(requestByteThresholdStr)) {
+      batchMutateBuilder.setRequestByteThreshold(Long.valueOf(requestByteThresholdStr));
+    }
+
+    builder
+        .bulkMutateRowsSettings()
+        .setBatchingSettings(batchMutateBuilder.build())
+        .setRetryableCodes(buildRetryCodes(builder.bulkMutateRowsSettings().getRetryableCodes()))
+        .setRetrySettings(
+            buildIdempotentRetrySettings(builder.bulkMutateRowsSettings().getRetrySettings()));
+  }
+
+  private void buildBulkReadRowsSettings(EnhancedBigtableStubSettings.Builder builder) {
+    BatchingSettings.Builder bulkReadBatchingBuilder =
+        builder.bulkReadRowsSettings().getBatchingSettings().toBuilder();
+
+    String bulkMaxRowKeyCountStr = configuration.get(BIGTABLE_BULK_MAX_ROW_KEY_COUNT);
+    if (!isNullOrEmpty(bulkMaxRowKeyCountStr)) {
+      bulkReadBatchingBuilder.setElementCountThreshold(Long.valueOf(bulkMaxRowKeyCountStr));
+    }
+
+    builder
+        .bulkReadRowsSettings()
+        .setBatchingSettings(bulkReadBatchingBuilder.build())
+        .setRetryableCodes(buildRetryCodes(builder.bulkReadRowsSettings().getRetryableCodes()))
+        .setRetrySettings(
+            buildIdempotentRetrySettings(builder.bulkReadRowsSettings().getRetrySettings()));
+  }
+
+  private void buildReadRowsSettings(EnhancedBigtableStubSettings.Builder stubSettings) {
+    RetrySettings.Builder retryBuilder =
+        stubSettings.readRowsSettings().getRetrySettings().toBuilder();
+
+    String initialElapsedBackoffMsStr = configuration.get(INITIAL_ELAPSED_BACKOFF_MILLIS_KEY);
+    if (!isNullOrEmpty(initialElapsedBackoffMsStr)) {
+      retryBuilder.setInitialRetryDelay(ofMillis(Long.valueOf(initialElapsedBackoffMsStr)));
+    }
+
+    String maxScanTimeoutRetriesAttempts = configuration.get(MAX_SCAN_TIMEOUT_RETRIES);
+    if (!isNullOrEmpty(maxScanTimeoutRetriesAttempts)) {
+      LOG.debug("gRPC max scan timeout retries (count): %d", maxScanTimeoutRetriesAttempts);
+      retryBuilder.setMaxAttempts(Integer.valueOf(maxScanTimeoutRetriesAttempts));
+    }
+
+    String rpcTimeoutStr = configuration.get(READ_PARTIAL_ROW_TIMEOUT_MS);
+    if (!isNullOrEmpty(rpcTimeoutStr)) {
+      Duration rpcTimeoutMs = ofMillis(Long.valueOf(rpcTimeoutStr));
+      retryBuilder.setInitialRpcTimeout(rpcTimeoutMs).setMaxRpcTimeout(rpcTimeoutMs);
+    }
+
+    if (Boolean.parseBoolean(configuration.get(BIGTABLE_USE_TIMEOUTS_KEY))) {
+      String readRowsRpcTimeoutMs = configuration.get(BIGTABLE_READ_RPC_TIMEOUT_MS_KEY);
+
+      if (!isNullOrEmpty(readRowsRpcTimeoutMs)) {
+        retryBuilder.setTotalTimeout(ofMillis(Long.valueOf(readRowsRpcTimeoutMs)));
+      }
+    } else {
+
+      String maxElapsedBackoffMillis = configuration.get(MAX_ELAPSED_BACKOFF_MILLIS_KEY);
+      if (!isNullOrEmpty(maxElapsedBackoffMillis)) {
+        retryBuilder.setTotalTimeout(ofMillis(Long.valueOf(maxElapsedBackoffMillis)));
+      }
+    }
+
+    stubSettings
+        .readRowsSettings()
+        .setRetryableCodes(buildRetryCodes(stubSettings.readRowsSettings().getRetryableCodes()))
+        .setRetrySettings(retryBuilder.build());
+  }
+  // </editor-fold>
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableHBaseVeneerSettings.java
@@ -102,6 +102,7 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
     super(configuration);
   }
 
+  // <editor-fold desc="Public API">
   @InternalApi
   public boolean isChannelPoolCachingEnabled() {
     // This is primarily used by Dataflow where connections open and close often. This is a
@@ -109,7 +110,6 @@ public class BigtableHBaseVeneerSettings extends BigtableHBaseSettings {
     return configuration.getBoolean(BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL, false);
   }
 
-  // <editor-fold desc="Public Utility">
   /**
    * Utility to convert {@link Configuration} to {@link BigtableDataSettings}.
    *

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BigtableVeneerApi.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.hbase.wrappers.AdminClientWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
+import java.io.IOException;
+
+public class BigtableVeneerApi extends BigtableWrapper {
+
+  private final BigtableHBaseVeneerSettings hbaseSettings;
+  private final DataClientWrapper dataClient;
+  private AdminClientWrapper adminClient;
+
+  BigtableVeneerApi(BigtableHBaseVeneerSettings hbaseSettings) throws IOException {
+    super(hbaseSettings);
+    this.hbaseSettings = hbaseSettings;
+    dataClient =
+        new DataClientVeneerApi(BigtableDataClient.create(hbaseSettings.getDataSettings()));
+  }
+
+  @Override
+  public AdminClientWrapper getAdminClientWrapper() throws IOException {
+    if (adminClient == null) {
+      adminClient =
+          new AdminClientVeneerApi(
+              BigtableTableAdminClient.create(hbaseSettings.getTableAdminSettings()));
+    }
+    return adminClient;
+  }
+
+  @Override
+  public DataClientWrapper getDataClientWrapper() {
+    return dataClient;
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkMutationVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkMutationVeneerApi.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.gax.batching.Batcher;
+import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
+import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+
+public class BulkMutationVeneerApi implements BulkMutationWrapper {
+
+  private final Batcher<RowMutationEntry, Void> bulkMutateBatcher;
+
+  public BulkMutationVeneerApi(Batcher<RowMutationEntry, Void> bulkMutateBatcher) {
+    this.bulkMutateBatcher = bulkMutateBatcher;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public synchronized ApiFuture<Void> add(RowMutationEntry rowMutation) {
+    Preconditions.checkNotNull(rowMutation, "mutation details cannot be null");
+    return bulkMutateBatcher.add(rowMutation);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void sendUnsent() {
+    bulkMutateBatcher.sendOutstanding();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void flush() {
+    try {
+      bulkMutateBatcher.flush();
+    } catch (InterruptedException ex) {
+      throw new RuntimeException("Could not complete RPC for current Batch", ex);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      bulkMutateBatcher.close();
+    } catch (InterruptedException e) {
+      throw new IOException("Could not close the bulk mutation Batcher", e);
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkReadVeneerApi.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.batching.Batcher;
+import com.google.bigtable.v2.ReadRowsRequest;
+import com.google.bigtable.v2.RowFilter;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
+import com.google.cloud.bigtable.data.v2.models.Filters;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
+import com.google.cloud.bigtable.hbase.wrappers.BulkReadWrapper;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.hbase.client.Result;
+
+public class BulkReadVeneerApi implements BulkReadWrapper {
+  private final String tableId;
+  private final BigtableDataClient dataClient;
+  private final RequestContext requestContext;
+  private final Map<RowFilter, Batcher<ByteString, Row>> batches;
+
+  public BulkReadVeneerApi(String tableId, BigtableDataClient dataClient) {
+    this.tableId = tableId;
+    this.dataClient = dataClient;
+    this.batches = new HashMap<>();
+    // required to retrieve the row key from Query instance
+    this.requestContext = RequestContext.create("", "", "");
+  }
+
+  @Override
+  public ApiFuture<Result> add(Query query) {
+    Preconditions.checkNotNull(query);
+    ReadRowsRequest request = query.toProto(requestContext);
+
+    Preconditions.checkArgument(request.getRows().getRowKeysCount() == 1);
+    ByteString rowKey = request.getRows().getRowKeysList().get(0);
+    Preconditions.checkArgument(!rowKey.equals(ByteString.EMPTY));
+
+    RowFilter filter = request.getFilter();
+    Batcher<ByteString, Row> batcher = batches.get(filter);
+    if (batcher == null) {
+      batcher = dataClient.newBulkReadRowsBatcher(tableId, Filters.FILTERS.fromProto(filter));
+      batches.put(filter, batcher);
+    }
+    return ApiFutures.transform(
+        batcher.add(rowKey),
+        new ApiFunction<Row, Result>() {
+          @Override
+          public Result apply(Row row) {
+            return Adapters.ROW_ADAPTER.adaptResponse(row);
+          }
+        },
+        MoreExecutors.directExecutor());
+  }
+
+  @Override
+  public void flush() {
+    // BulkRead#flush() doesn't wait till entries are resolved.
+    for (Batcher<ByteString, Row> batch : batches.values()) {
+      batch.sendOutstanding();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    try {
+      for (Batcher<ByteString, Row> batch : batches.values()) {
+        batch.close();
+      }
+    } catch (InterruptedException exception) {
+      throw new IOException("Could not close the bulk read Batcher", exception);
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/DataClientVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/DataClientVeneerApi.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import com.google.api.core.ApiFunction;
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.gax.rpc.StateCheckingResponseObserver;
+import com.google.api.gax.rpc.StreamController;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
+import com.google.cloud.bigtable.data.v2.models.KeyOffset;
+import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
+import com.google.cloud.bigtable.data.v2.models.Row;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
+import com.google.cloud.bigtable.hbase.adapters.read.ResultRowAdapter;
+import com.google.cloud.bigtable.hbase.adapters.read.ResultScannerExtended;
+import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.BulkReadWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.grpc.stub.StreamObserver;
+import java.util.List;
+import org.apache.hadoop.hbase.client.Result;
+
+public class DataClientVeneerApi implements DataClientWrapper {
+
+  private final BigtableDataClient delegate;
+
+  DataClientVeneerApi(BigtableDataClient delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public BulkMutationWrapper createBulkMutationWrapper(String tableId) {
+    return new BulkMutationVeneerApi(delegate.newBulkMutationBatcher(tableId));
+  }
+
+  @Override
+  public BulkReadWrapper createBulkReadWrapper(String tableId) {
+    return new BulkReadVeneerApi(tableId, delegate);
+  }
+
+  @Override
+  public ApiFuture<Void> mutateRowsAsync(RowMutation rowMutation) {
+    return delegate.mutateRowAsync(rowMutation);
+  }
+
+  @Override
+  public ApiFuture<Result> readModifyRowsAsync(ReadModifyWriteRow readModifyWriteRow) {
+    return ApiFutures.transform(
+        delegate.readModifyWriteRowAsync(readModifyWriteRow),
+        new ApiFunction<Row, Result>() {
+          @Override
+          public Result apply(Row row) {
+            return Adapters.ROW_ADAPTER.adaptResponse(row);
+          }
+        },
+        MoreExecutors.directExecutor());
+  }
+
+  @Override
+  public ApiFuture<Boolean> checkAndMutateRowAsync(ConditionalRowMutation conditionalRowMutation) {
+    return delegate.checkAndMutateRowAsync(conditionalRowMutation);
+  }
+
+  @Override
+  public ApiFuture<List<KeyOffset>> sampleRowKeysAsync(String tableId) {
+    return delegate.sampleRowKeysAsync(tableId);
+  }
+
+  @Override
+  public ResultScanner<Result> readRows(Query request) {
+    return new ResultScannerExtended<>(
+        delegate.readRowsCallable(new ResultRowAdapter()).call(request), new Result[0]);
+  }
+
+  @Override
+  public ApiFuture<List<Result>> readRowsAsync(Query request) {
+    return delegate.readRowsCallable(new ResultRowAdapter()).all().futureCall(request);
+  }
+
+  @Override
+  public void readRowsAsync(Query request, StreamObserver<Result> observer) {
+    delegate
+        .readRowsCallable(new ResultRowAdapter())
+        .call(request, new StreamObserverAdapter<>(observer));
+  }
+
+  @Override
+  public void close() throws Exception {
+    delegate.close();
+  }
+
+  /**
+   * To wrap stream of native CBT client's {@link StreamObserver} onto GCJ {@link
+   * com.google.api.gax.rpc.ResponseObserver}.
+   */
+  private static class StreamObserverAdapter<T> extends StateCheckingResponseObserver<T> {
+    private final StreamObserver<T> delegate;
+
+    StreamObserverAdapter(StreamObserver<T> delegate) {
+      this.delegate = delegate;
+    }
+
+    protected void onStartImpl(StreamController controller) {}
+
+    protected void onResponseImpl(T response) {
+      this.delegate.onNext(response);
+    }
+
+    protected void onErrorImpl(Throwable t) {
+      this.delegate.onError(t);
+    }
+
+    protected void onCompleteImpl() {
+      this.delegate.onCompleted();
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/TestBigtableHBaseClassicSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/TestBigtableHBaseClassicSettings.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.google.auth.Credentials;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.config.CredentialFactory;
+import com.google.cloud.bigtable.config.RetryOptions;
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.wrappers.classic.BigtableHBaseClassicSettings;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class TestBigtableHBaseClassicSettings {
+
+  private static final String TEST_HOST = "localhost";
+  private static final String TEST_PROJECT_ID = "project-foo";
+  private static final String TEST_INSTANCE_ID = "test-instance";
+
+  private Configuration configuration;
+
+  @Before
+  public void setup() {
+    configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
+  }
+
+  @Test
+  public void testProjectIdIsRequired() {
+    Configuration configuration = new Configuration(false);
+    configuration.unset(BigtableOptionsFactory.PROJECT_ID_KEY);
+
+    try {
+      BigtableHBaseSettings.create(configuration);
+    } catch (IllegalArgumentException ex) {
+      assertEquals("Project ID must be supplied via google.bigtable.project.id", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testHostIsRequired() {
+    Configuration configuration = new Configuration(false);
+    configuration.unset(BigtableOptionsFactory.BIGTABLE_HOST_KEY);
+
+    try {
+      BigtableHBaseSettings.create(configuration);
+    } catch (IllegalArgumentException ex) {
+      assertEquals("Project ID must be supplied via google.bigtable.project.id", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testInstanceIsRequired() {
+    Configuration configuration = new Configuration(false);
+    configuration.unset(BigtableOptionsFactory.INSTANCE_ID_KEY);
+
+    try {
+      BigtableHBaseSettings.create(configuration);
+    } catch (IllegalArgumentException ex) {
+      assertEquals("Project ID must be supplied via google.bigtable.project.id", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testConnectionKeysAreUsed() throws IOException {
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, "data-host");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY, "admin-host");
+    configuration.setInt(BigtableOptionsFactory.BIGTABLE_PORT_KEY, 1234);
+    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
+    BigtableOptions options =
+        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
+            .getBigtableOptions();
+
+    assertEquals("data-host", options.getDataHost());
+    assertEquals("admin-host", options.getAdminHost());
+    assertEquals(1234, options.getPort());
+    assertTrue(
+        "BIGTABLE_USE_PLAINTEXT_NEGOTIATION was not propagated", options.usePlaintextNegotiation());
+  }
+
+  @Test
+  public void testOptionsAreConstructedWithValidInput() throws IOException {
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, false);
+    configuration.setBoolean(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
+
+    BigtableOptions options =
+        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
+            .getBigtableOptions();
+
+    assertEquals(TEST_HOST, options.getDataHost());
+    assertEquals(TEST_PROJECT_ID, options.getProjectId());
+    assertEquals(TEST_INSTANCE_ID, options.getInstanceId());
+  }
+
+  @Test
+  public void testDefaultRetryOptions() throws IOException {
+    BigtableOptions options =
+        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
+            .getBigtableOptions();
+    RetryOptions retryOptions = options.getRetryOptions();
+
+    assertEquals(RetryOptions.DEFAULT_ENABLE_GRPC_RETRIES, retryOptions.enableRetries());
+    assertEquals(
+        RetryOptions.DEFAULT_MAX_ELAPSED_BACKOFF_MILLIS, retryOptions.getMaxElapsedBackoffMillis());
+    assertEquals(
+        RetryOptions.DEFAULT_READ_PARTIAL_ROW_TIMEOUT_MS,
+        retryOptions.getReadPartialRowTimeoutMillis());
+    assertEquals(
+        RetryOptions.DEFAULT_MAX_SCAN_TIMEOUT_RETRIES, retryOptions.getMaxScanTimeoutRetries());
+  }
+
+  @Test
+  public void testSettingRetryOptions() throws IOException {
+    configuration.set(BigtableOptionsFactory.ENABLE_GRPC_RETRIES_KEY, "false");
+    configuration.set(BigtableOptionsFactory.ENABLE_GRPC_RETRY_DEADLINEEXCEEDED_KEY, "false");
+    configuration.set(BigtableOptionsFactory.MAX_ELAPSED_BACKOFF_MILLIS_KEY, "111");
+    configuration.set(BigtableOptionsFactory.READ_PARTIAL_ROW_TIMEOUT_MS, "123");
+
+    BigtableOptions options =
+        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
+            .getBigtableOptions();
+    RetryOptions retryOptions = options.getRetryOptions();
+
+    assertFalse(retryOptions.enableRetries());
+    assertFalse(retryOptions.retryOnDeadlineExceeded());
+    assertEquals(111, retryOptions.getMaxElapsedBackoffMillis());
+    assertEquals(123, retryOptions.getReadPartialRowTimeoutMillis());
+  }
+
+  @Test
+  public void testExplicitCredentials() throws IOException, GeneralSecurityException {
+    Credentials credentials = Mockito.mock(Credentials.class);
+    configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
+    configuration = BigtableConfiguration.withCredentials(configuration, credentials);
+
+    BigtableOptions options =
+        ((BigtableHBaseClassicSettings) BigtableHBaseSettings.create(configuration))
+            .getBigtableOptions();
+    Credentials actualCreds = CredentialFactory.getCredentials(options.getCredentialOptions());
+
+    Assert.assertSame(credentials, actualCreds);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.veneer;
+
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ADDITIONAL_RETRY_CODES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ALLOW_NO_TIMESTAMP_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.APP_PROFILE_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_AUTOFLUSH_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_BULK_MAX_ROW_KEY_COUNT;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_PORT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_READ_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_RPC_TIMEOUT_MS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_PLAINTEXT_NEGOTIATION;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_SERVICE_ACCOUNTS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.BIGTABLE_USE_TIMEOUTS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.ENABLE_GRPC_RETRIES_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INITIAL_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_ELAPSED_BACKOFF_MILLIS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_INFLIGHT_RPCS_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.MAX_SCAN_TIMEOUT_RETRIES;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.READ_PARTIAL_ROW_TIMEOUT_MS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.threeten.bp.Duration.ofMillis;
+
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.core.CredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
+import com.google.api.gax.retrying.RetrySettings;
+import com.google.auth.Credentials;
+import com.google.cloud.bigtable.admin.v2.BigtableInstanceAdminSettings;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.hbase.BigtableConfiguration;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import io.grpc.internal.GrpcUtil;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class TestBigtableHBaseVeneerSettings {
+
+  private static final String TEST_HOST = "localhost";
+  private static final int TEST_PORT = 80;
+  private static final String TEST_PROJECT_ID = "project-foo";
+  private static final String TEST_INSTANCE_ID = "test-instance";
+
+  private Configuration configuration;
+
+  @Before
+  public void setup() {
+    configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_USE_GCJ_CLIENT, "true");
+  }
+
+  @Test
+  public void testDataSettingsBasicKeys() throws IOException {
+    String appProfileId = "appProfileId";
+    String userAgent = "test-user-agent";
+    Credentials credentials = Mockito.mock(Credentials.class);
+
+    configuration.set(BIGTABLE_PORT_KEY, String.valueOf(TEST_PORT));
+    configuration.set(APP_PROFILE_ID_KEY, appProfileId);
+    configuration.setBoolean(BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
+    configuration.set(CUSTOM_USER_AGENT_KEY, userAgent);
+    configuration.setInt(BIGTABLE_DATA_CHANNEL_COUNT_KEY, 3);
+    configuration.set(BIGTABLE_USE_CACHED_DATA_CHANNEL_POOL, "true");
+    configuration.set(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, "true");
+    configuration = BigtableConfiguration.withCredentials(configuration, credentials);
+
+    BigtableHBaseVeneerSettings settingUtils =
+        (BigtableHBaseVeneerSettings) BigtableHBaseSettings.create(configuration);
+
+    BigtableDataSettings dataSettings = settingUtils.getDataSettings();
+    assertEquals(TEST_PROJECT_ID, dataSettings.getProjectId());
+    assertEquals(TEST_INSTANCE_ID, dataSettings.getInstanceId());
+    assertEquals(appProfileId, dataSettings.getAppProfileId());
+
+    assertEquals(TEST_HOST + ":" + TEST_PORT, dataSettings.getStubSettings().getEndpoint());
+    Map<String, String> headers = dataSettings.getStubSettings().getHeaderProvider().getHeaders();
+    assertTrue(headers.get(GrpcUtil.USER_AGENT_KEY.name()).contains(userAgent));
+    assertEquals(
+        credentials, dataSettings.getStubSettings().getCredentialsProvider().getCredentials());
+
+    assertTrue(settingUtils.isChannelPoolCachingEnabled());
+  }
+
+  @Test
+  public void testAdminSettingsBasicKeys() throws IOException {
+    String adminHost = "testadmin.example.com";
+    String userAgent = "test-user-agent";
+    Credentials credentials = Mockito.mock(Credentials.class);
+
+    configuration.set(BIGTABLE_ADMIN_HOST_KEY, adminHost);
+    configuration.setInt(BIGTABLE_PORT_KEY, TEST_PORT);
+    configuration.set(CUSTOM_USER_AGENT_KEY, userAgent);
+    configuration.setBoolean(BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
+    configuration.set(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, "true");
+    configuration = BigtableConfiguration.withCredentials(configuration, credentials);
+
+    BigtableHBaseVeneerSettings settings =
+        (BigtableHBaseVeneerSettings) BigtableHBaseSettings.create(configuration);
+    BigtableTableAdminSettings adminSettings = settings.getTableAdminSettings();
+    assertEquals(TEST_PROJECT_ID, adminSettings.getProjectId());
+    assertEquals(TEST_INSTANCE_ID, adminSettings.getInstanceId());
+
+    assertEquals(adminHost + ":" + TEST_PORT, adminSettings.getStubSettings().getEndpoint());
+    Map<String, String> headers = adminSettings.getStubSettings().getHeaderProvider().getHeaders();
+    assertTrue(headers.get(GrpcUtil.USER_AGENT_KEY.name()).contains(userAgent));
+    assertEquals(
+        credentials, adminSettings.getStubSettings().getCredentialsProvider().getCredentials());
+  }
+
+  @Test
+  public void testInstanceAdminSettingsBasicKeys() throws IOException {
+    String userAgent = "test-user-agent";
+    Credentials credentials = Mockito.mock(Credentials.class);
+
+    configuration.set(CUSTOM_USER_AGENT_KEY, userAgent);
+    configuration.set(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, "true");
+    configuration = BigtableConfiguration.withCredentials(configuration, credentials);
+
+    BigtableHBaseVeneerSettings settings =
+        (BigtableHBaseVeneerSettings) BigtableHBaseSettings.create(configuration);
+    BigtableInstanceAdminSettings instanceAdminSettings = settings.getInstanceAdminSettings();
+    assertEquals(TEST_PROJECT_ID, instanceAdminSettings.getProjectId());
+
+    Map<String, String> headers =
+        instanceAdminSettings.getStubSettings().getHeaderProvider().getHeaders();
+    assertTrue(headers.get(GrpcUtil.USER_AGENT_KEY.name()).contains(userAgent));
+    assertEquals(
+        credentials,
+        instanceAdminSettings.getStubSettings().getCredentialsProvider().getCredentials());
+  }
+
+  @Test
+  public void testTimeoutBeingPassed() throws IOException {
+    int initialElapsedMs = 100;
+    int rpcTimeoutMs = 500;
+    int maxElapsedMs = 1000;
+    int maxAttempt = 10;
+    int readRowStreamTimeout = 30000;
+    configuration.setBoolean(BIGTABLE_USE_TIMEOUTS_KEY, true);
+    configuration.setInt(INITIAL_ELAPSED_BACKOFF_MILLIS_KEY, initialElapsedMs);
+    configuration.setInt(BIGTABLE_RPC_TIMEOUT_MS_KEY, rpcTimeoutMs);
+    configuration.setInt(MAX_ELAPSED_BACKOFF_MILLIS_KEY, maxElapsedMs);
+    configuration.setInt(READ_PARTIAL_ROW_TIMEOUT_MS, rpcTimeoutMs);
+    configuration.setLong(MAX_SCAN_TIMEOUT_RETRIES, maxAttempt);
+    configuration.setInt(BIGTABLE_READ_RPC_TIMEOUT_MS_KEY, readRowStreamTimeout);
+    BigtableDataSettings settings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+
+    RetrySettings readRowRetrySettings =
+        settings.getStubSettings().readRowSettings().getRetrySettings();
+    assertEquals(initialElapsedMs, readRowRetrySettings.getInitialRetryDelay().toMillis());
+    assertEquals(rpcTimeoutMs, readRowRetrySettings.getInitialRpcTimeout().toMillis());
+    assertEquals(maxElapsedMs, readRowRetrySettings.getTotalTimeout().toMillis());
+
+    RetrySettings checkAndMutateRetrySettings =
+        settings.getStubSettings().checkAndMutateRowSettings().getRetrySettings();
+    assertEquals(0, checkAndMutateRetrySettings.getInitialRetryDelay().toMillis());
+    assertEquals(rpcTimeoutMs, checkAndMutateRetrySettings.getTotalTimeout().toMillis());
+
+    RetrySettings readRowsRetrySettings =
+        settings.getStubSettings().readRowsSettings().getRetrySettings();
+    assertEquals(initialElapsedMs, readRowsRetrySettings.getInitialRetryDelay().toMillis());
+    assertEquals(maxAttempt, readRowsRetrySettings.getMaxAttempts());
+    assertEquals(readRowStreamTimeout, readRowsRetrySettings.getTotalTimeout().toMillis());
+  }
+
+  @Test
+  public void testRetriesWithoutTimestamp() throws IOException {
+    configuration.setBoolean(BIGTABLE_USE_PLAINTEXT_NEGOTIATION, true);
+    configuration.setBoolean(ALLOW_NO_TIMESTAMP_RETRIES_KEY, true);
+
+    try {
+      ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+          .getDataSettings();
+      Assert.fail("BigtableDataSettings should not support retries without timestamp");
+    } catch (UnsupportedOperationException actualException) {
+
+      assertEquals("Retries without Timestamp is not supported yet.", actualException.getMessage());
+    }
+  }
+
+  @Test
+  public void testWhenRetriesAreDisabled() throws IOException {
+    configuration.setBoolean(ENABLE_GRPC_RETRIES_KEY, false);
+    BigtableDataSettings dataSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+    assertTrue(
+        dataSettings.getStubSettings().bulkMutateRowsSettings().getRetryableCodes().isEmpty());
+    assertTrue(dataSettings.getStubSettings().readRowSettings().getRetryableCodes().isEmpty());
+    assertTrue(dataSettings.getStubSettings().readRowsSettings().getRetryableCodes().isEmpty());
+    assertTrue(
+        dataSettings.getStubSettings().sampleRowKeysSettings().getRetryableCodes().isEmpty());
+  }
+
+  @Test
+  public void testWithNullCredentials() throws IOException {
+    configuration.set(ADDITIONAL_RETRY_CODES, "UNAVAILABLE,ABORTED");
+    configuration.setBoolean(BIGTABLE_USE_SERVICE_ACCOUNTS_KEY, false);
+    configuration.setBoolean(BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, true);
+
+    BigtableDataSettings dataSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+    assertTrue(
+        dataSettings.getStubSettings().getCredentialsProvider() instanceof NoCredentialsProvider);
+    assertNull(dataSettings.getStubSettings().getCredentialsProvider().getCredentials());
+
+    BigtableTableAdminSettings adminSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getTableAdminSettings();
+    assertTrue(
+        adminSettings.getStubSettings().getCredentialsProvider() instanceof NoCredentialsProvider);
+    assertNull(adminSettings.getStubSettings().getCredentialsProvider().getCredentials());
+  }
+
+  @Test
+  public void testVerifyRetrySettings() throws IOException {
+    BigtableDataSettings dataSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+    BigtableDataSettings.Builder defaultDataSettings = BigtableDataSettings.newBuilder();
+
+    assertEquals(
+        defaultDataSettings.stubSettings().readRowsSettings().getRetryableCodes(),
+        dataSettings.getStubSettings().readRowsSettings().getRetryableCodes());
+
+    // Unary operation's RetrySettings & RetryCodes of retryable methods.
+    assertRetrySettings(
+        defaultDataSettings.stubSettings().readRowSettings().getRetrySettings(),
+        dataSettings.getStubSettings().readRowSettings().getRetrySettings());
+    assertEquals(
+        defaultDataSettings.stubSettings().readRowSettings().getRetryableCodes(),
+        dataSettings.getStubSettings().readRowSettings().getRetryableCodes());
+
+    assertRetrySettings(
+        defaultDataSettings.stubSettings().mutateRowSettings().getRetrySettings(),
+        dataSettings.getStubSettings().mutateRowSettings().getRetrySettings());
+    assertEquals(
+        defaultDataSettings.stubSettings().mutateRowSettings().getRetryableCodes(),
+        dataSettings.getStubSettings().mutateRowSettings().getRetryableCodes());
+
+    assertRetrySettings(
+        defaultDataSettings.stubSettings().sampleRowKeysSettings().getRetrySettings(),
+        dataSettings.getStubSettings().sampleRowKeysSettings().getRetrySettings());
+    assertEquals(
+        defaultDataSettings.stubSettings().sampleRowKeysSettings().getRetryableCodes(),
+        dataSettings.getStubSettings().sampleRowKeysSettings().getRetryableCodes());
+
+    // Non-streaming operation's verifying RetrySettings & RetryCodes of non-retryable methods.
+    // readModifyWriteRowSettings
+    assertDisabledRetrySettings(
+        defaultDataSettings.stubSettings().readModifyWriteRowSettings().getRetrySettings(),
+        dataSettings.getStubSettings().readModifyWriteRowSettings().getRetrySettings());
+    assertTrue(
+        dataSettings.getStubSettings().readModifyWriteRowSettings().getRetryableCodes().isEmpty());
+
+    // checkAndMutateRowSettings
+    assertDisabledRetrySettings(
+        defaultDataSettings.stubSettings().readModifyWriteRowSettings().getRetrySettings(),
+        dataSettings.getStubSettings().checkAndMutateRowSettings().getRetrySettings());
+    assertTrue(
+        dataSettings.getStubSettings().checkAndMutateRowSettings().getRetryableCodes().isEmpty());
+  }
+
+  private void assertRetrySettings(RetrySettings expected, RetrySettings actual) {
+    assertEquals(expected.getInitialRetryDelay(), actual.getInitialRetryDelay());
+    assertEquals(expected.getMaxRetryDelay(), actual.getMaxRetryDelay());
+    assertEquals(expected.getMaxAttempts(), actual.getMaxAttempts());
+    assertEquals(expected.getInitialRpcTimeout(), actual.getInitialRpcTimeout());
+    assertEquals(expected.getMaxRpcTimeout(), actual.getMaxRpcTimeout());
+    assertEquals(expected.getTotalTimeout(), actual.getTotalTimeout());
+  }
+
+  private void assertDisabledRetrySettings(RetrySettings expected, RetrySettings actual) {
+    assertEquals(expected.getInitialRetryDelay(), actual.getInitialRetryDelay());
+    assertEquals(expected.getRetryDelayMultiplier(), actual.getRetryDelayMultiplier(), 0);
+    assertEquals(expected.getMaxRetryDelay(), actual.getMaxRetryDelay());
+    assertEquals(expected.getMaxAttempts(), actual.getMaxAttempts());
+    assertEquals(expected.getInitialRpcTimeout(), actual.getInitialRpcTimeout());
+    assertEquals(expected.getMaxRpcTimeout(), actual.getMaxRpcTimeout());
+    assertEquals(expected.getTotalTimeout(), actual.getTotalTimeout());
+  }
+
+  @Test
+  public void testBulkMutationConfiguration() throws IOException {
+    long autoFlushMs = 2000L;
+    long maxRowKeyCount = 100L;
+    long maxInflightRPC = 500L;
+    long maxMemory = 100 * 1024L;
+    long bulkMaxReqSize = 20 * 1024;
+
+    configuration.setLong(BIGTABLE_BULK_AUTOFLUSH_MS_KEY, autoFlushMs);
+    configuration.setLong(BIGTABLE_BULK_MAX_ROW_KEY_COUNT, maxRowKeyCount);
+    configuration.setLong(MAX_INFLIGHT_RPCS_KEY, maxInflightRPC);
+    configuration.setLong(BIGTABLE_BULK_MAX_REQUEST_SIZE_BYTES, bulkMaxReqSize);
+    configuration.setLong(MAX_ELAPSED_BACKOFF_MILLIS_KEY, autoFlushMs);
+    configuration.setLong(BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY, maxMemory);
+
+    BigtableDataSettings settings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+
+    BatchingSettings batchingSettings =
+        settings.getStubSettings().bulkMutateRowsSettings().getBatchingSettings();
+    assertEquals(ofMillis(autoFlushMs), batchingSettings.getDelayThreshold());
+    assertEquals(Long.valueOf(bulkMaxReqSize), batchingSettings.getRequestByteThreshold());
+    assertEquals(Long.valueOf(maxRowKeyCount), batchingSettings.getElementCountThreshold());
+    assertEquals(
+        Long.valueOf(maxInflightRPC * maxRowKeyCount),
+        batchingSettings.getFlowControlSettings().getMaxOutstandingElementCount());
+    assertEquals(
+        Long.valueOf(maxMemory),
+        batchingSettings.getFlowControlSettings().getMaxOutstandingRequestBytes());
+  }
+
+  @Test
+  public void testDataSettingsWithEmulator() throws IOException {
+    ServerSocket serverSocket = new ServerSocket(0);
+    final int availablePort = serverSocket.getLocalPort();
+    serverSocket.close();
+    String emulatorHost = "localhost:" + availablePort;
+    configuration.set(BIGTABLE_EMULATOR_HOST_KEY, emulatorHost);
+
+    BigtableDataSettings dataSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getDataSettings();
+
+    assertEquals(emulatorHost, dataSettings.getStubSettings().getEndpoint());
+    CredentialsProvider credProvider = dataSettings.getStubSettings().getCredentialsProvider();
+    assertTrue(credProvider instanceof NoCredentialsProvider);
+  }
+
+  @Test
+  public void testAdminSettingsWithEmulator() throws IOException {
+    ServerSocket serverSocket = new ServerSocket(0);
+    final int availablePort = serverSocket.getLocalPort();
+    serverSocket.close();
+    String emulatorHost = "localhost:" + availablePort;
+    configuration.set(BIGTABLE_EMULATOR_HOST_KEY, emulatorHost);
+
+    BigtableTableAdminSettings adminSettings =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
+            .getTableAdminSettings();
+
+    assertEquals(emulatorHost, adminSettings.getStubSettings().getEndpoint());
+    CredentialsProvider credProvider = adminSettings.getStubSettings().getCredentialsProvider();
+    assertTrue(credProvider instanceof NoCredentialsProvider);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBigtableHBaseVeneerSettings.java
@@ -82,6 +82,7 @@ public class TestBigtableHBaseVeneerSettings {
   public void setup() {
     configuration = new Configuration(false);
     configuration.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, TEST_HOST);
+    configuration.set(BIGTABLE_ADMIN_HOST_KEY, TEST_HOST);
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_USE_GCJ_CLIENT, "true");
@@ -109,6 +110,10 @@ public class TestBigtableHBaseVeneerSettings {
     assertEquals(TEST_PROJECT_ID, dataSettings.getProjectId());
     assertEquals(TEST_INSTANCE_ID, dataSettings.getInstanceId());
     assertEquals(appProfileId, dataSettings.getAppProfileId());
+
+    assertEquals(TEST_HOST, settingUtils.getDataHost());
+    assertEquals(TEST_PORT, settingUtils.getPort());
+    assertEquals(TEST_HOST, settingUtils.getAdminHost());
 
     assertEquals(TEST_HOST + ":" + TEST_PORT, dataSettings.getStubSettings().getEndpoint());
     Map<String, String> headers = dataSettings.getStubSettings().getHeaderProvider().getHeaders();
@@ -336,14 +341,15 @@ public class TestBigtableHBaseVeneerSettings {
     configuration.setLong(MAX_ELAPSED_BACKOFF_MILLIS_KEY, autoFlushMs);
     configuration.setLong(BIGTABLE_BUFFERED_MUTATOR_MAX_MEMORY_KEY, maxMemory);
 
-    BigtableDataSettings settings =
-        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration))
-            .getDataSettings();
+    BigtableHBaseVeneerSettings settingUtils =
+        ((BigtableHBaseVeneerSettings) BigtableHBaseVeneerSettings.create(configuration));
+    BigtableDataSettings settings = settingUtils.getDataSettings();
 
     BatchingSettings batchingSettings =
         settings.getStubSettings().bulkMutateRowsSettings().getBatchingSettings();
     assertEquals(ofMillis(autoFlushMs), batchingSettings.getDelayThreshold());
     assertEquals(Long.valueOf(bulkMaxReqSize), batchingSettings.getRequestByteThreshold());
+    assertEquals(maxRowKeyCount, settingUtils.getBulkMaxRowCount());
     assertEquals(Long.valueOf(maxRowKeyCount), batchingSettings.getElementCountThreshold());
     assertEquals(
         Long.valueOf(maxInflightRPC * maxRowKeyCount),


### PR DESCRIPTION
This is still in progress.

moved ResultRowAdapter and ResultScannerExtended inside `adapters.read` package