### PR TITLE
chore: adds BigtableWrapper which with classic implementation

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/pom.xml
+++ b/bigtable-client-core-parent/bigtable-hbase/pom.xml
@@ -86,6 +86,10 @@ limitations under the License.
       <artifactId>proto-google-common-protos</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-credentials</artifactId>
     </dependency>

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableWrapper.java
@@ -43,7 +43,7 @@ public abstract class BigtableWrapper implements AutoCloseable {
     this.hBaseSettings = hbaseSettings;
   }
 
-  public abstract AdminClientWrapper getAdminClient() throws IOException;
+  public abstract AdminClientWrapper getAdminClient();
 
   public abstract DataClientWrapper getDataClient();
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableWrapper.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers;
+
+import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.hbase.wrappers.classic.BigtableClassicApi;
+import com.google.cloud.bigtable.hbase.wrappers.classic.BigtableHBaseClassicSettings;
+import com.google.cloud.bigtable.hbase.wrappers.veneer.BigtableHBaseVeneerSettings;
+import java.io.IOException;
+
+/**
+ * Common API surface for settings, data and admin client across this library.
+ *
+ * <p>For internal use only - public for technical reasons.
+ */
+@InternalApi("For internal usage only")
+public abstract class BigtableWrapper implements AutoCloseable {
+
+  private final BigtableHBaseSettings hBaseSettings;
+
+  public static BigtableWrapper create(BigtableHBaseSettings settings) throws IOException {
+    if (settings instanceof BigtableHBaseVeneerSettings) {
+      throw new UnsupportedOperationException("Veneer client is not yet supported.");
+    } else {
+      return new BigtableClassicApi((BigtableHBaseClassicSettings) settings);
+    }
+  }
+
+  protected BigtableWrapper(BigtableHBaseSettings hbaseSettings) {
+    this.hBaseSettings = hbaseSettings;
+  }
+
+  public abstract AdminClientWrapper getAdminClient() throws IOException;
+
+  public abstract DataClientWrapper getDataClient();
+
+  public BigtableHBaseSettings getBigtableHBaseSettings() {
+    return hBaseSettings;
+  }
+}

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableClassicApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableClassicApi.java
@@ -30,31 +30,28 @@ public class BigtableClassicApi extends BigtableWrapper {
 
   private final BigtableSession bigtableSession;
   private final DataClientWrapper dataClientWrapper;
-
-  // Delaying the admin wrapper instantiation until its needed
-  private AdminClientWrapper adminClientWrapper;
+  private final AdminClientWrapper adminClientWrapper;
 
   public BigtableClassicApi(BigtableHBaseClassicSettings settings) throws IOException {
     super(settings);
     this.bigtableSession = new BigtableSession(settings.getBigtableOptions());
+
     RequestContext requestContext =
         RequestContext.create(
             settings.getProjectId(),
             settings.getInstanceId(),
             settings.getBigtableOptions().getAppProfileId());
     this.dataClientWrapper = new DataClientClassicApi(bigtableSession, requestContext);
+
+    BigtableInstanceName instanceName =
+        new BigtableInstanceName(
+            getBigtableHBaseSettings().getProjectId(), getBigtableHBaseSettings().getInstanceId());
+    this.adminClientWrapper =
+        new AdminClientClassicApi(bigtableSession.getTableAdminClient(), instanceName);
   }
 
   @Override
-  public AdminClientWrapper getAdminClient() throws IOException {
-    if (adminClientWrapper == null) {
-      BigtableInstanceName instanceName =
-          new BigtableInstanceName(
-              getBigtableHBaseSettings().getProjectId(),
-              getBigtableHBaseSettings().getInstanceId());
-      adminClientWrapper =
-          new AdminClientClassicApi(bigtableSession.getTableAdminClient(), instanceName);
-    }
+  public AdminClientWrapper getAdminClient() {
     return adminClientWrapper;
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableClassicApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC.
+ * Copyright 2020 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestBigtableClassicApi.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase.wrappers.classic;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableWrapper;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import java.io.IOException;
+import java.net.ServerSocket;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestBigtableClassicApi {
+
+  private static final String TEST_PROJECT_ID = "fake-project-id";
+  private static final String TEST_INSTANCE_ID = "fake-instance-id";
+
+  private static Server server;
+  private static int port;
+
+  private BigtableHBaseSettings bigtableHBaseSettings;
+  private BigtableWrapper bigtableWrapper;
+
+  @BeforeClass
+  public static void setUpServer() throws IOException {
+    try (ServerSocket s = new ServerSocket(0)) {
+      port = s.getLocalPort();
+    }
+    server = ServerBuilder.forPort(port).addService(new BigtableGrpc.BigtableImplBase() {}).build();
+    server.start();
+  }
+
+  @AfterClass
+  public static void tearDownServer() throws InterruptedException {
+    if (server != null) {
+      server.shutdownNow();
+      server.awaitTermination();
+    }
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    Configuration configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + port);
+    bigtableHBaseSettings = BigtableHBaseClassicSettings.create(configuration);
+    bigtableWrapper = BigtableWrapper.create(bigtableHBaseSettings);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    bigtableWrapper.close();
+  }
+
+  @Test
+  public void testAdminClient() throws IOException {
+    assertTrue(bigtableWrapper.getAdminClient() instanceof AdminClientClassicApi);
+  }
+
+  @Test
+  public void testDataClient() {
+    assertTrue(bigtableWrapper.getDataClient() instanceof DataClientClassicApi);
+  }
+
+  @Test
+  public void testBigtableHBaseSettings() {
+    assertEquals(bigtableHBaseSettings, bigtableWrapper.getBigtableHBaseSettings());
+  }
+}


### PR DESCRIPTION
This change contains `BigtableWrapper`, The intention with this class is to replace `BigtableSession` references across `bigtable-hbase` & it's child modules.

Note: BigtableInstanceAdmin is not yet exposed through BigtableWrapper(we may add it once migrating data & admin operations).