### PR TITLE
chore: part 3 of replacing BigtableOptions to BigtableHBaseSettings

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableRegionLocator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableRegionLocator.java
@@ -20,12 +20,13 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
@@ -56,11 +57,16 @@ public abstract class AbstractBigtableRegionLocator {
   private long regionsFetchTimeMillis;
 
   public AbstractBigtableRegionLocator(
-      TableName tableName, BigtableOptions options, IBigtableDataClient client) {
+      TableName tableName, BigtableHBaseSettings settings, IBigtableDataClient client) {
     this.tableName = tableName;
     this.client = client;
-    this.bigtableTableName = options.getInstanceName().toTableName(tableName.getNameAsString());
-    ServerName serverName = ServerName.valueOf(options.getDataHost(), options.getPort(), 0);
+    this.bigtableTableName =
+        new BigtableTableName(
+            NameUtil.formatTableName(
+                settings.getProjectId(),
+                settings.getInstanceId(),
+                tableName.getQualifierAsString()));
+    ServerName serverName = ServerName.valueOf(settings.getDataHost(), settings.getPort(), 0);
     this.adapter = getSampledRowKeysAdapter(tableName, serverName);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -696,7 +696,11 @@ public abstract class AbstractBigtableTable implements Table {
    */
   protected synchronized BatchExecutor getBatchExecutor() {
     if (batchExecutor == null) {
-      batchExecutor = new BatchExecutor(bigtableConnection.getSession(), hbaseAdapter);
+      batchExecutor =
+          new BatchExecutor(
+              bigtableConnection.getSession(),
+              bigtableConnection.getBigtableHBaseSettings(),
+              hbaseAdapter);
     }
     return batchExecutor;
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -22,6 +22,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -64,18 +65,18 @@ public class BigtableBufferedMutator implements BufferedMutator {
    * Constructor for BigtableBufferedMutator.
    *
    * @param adapter Converts HBase objects to Bigtable protos
-   * @param configuration For Additional configuration. TODO: move this to options
+   * @param settings For bigtable settings
    * @param listener Handles exceptions. By default, it just throws the exception.
    * @param session a {@link BigtableSession} object.
    */
   public BigtableBufferedMutator(
       HBaseRequestAdapter adapter,
-      Configuration configuration,
+      BigtableHBaseSettings settings,
       BigtableSession session,
       BufferedMutator.ExceptionListener listener) {
-    helper = new BigtableBufferedMutatorHelper(adapter, configuration, session);
+    helper = new BigtableBufferedMutatorHelper(adapter, settings, session);
     this.listener = listener;
-    this.host = session.getOptions().getDataHost();
+    this.host = settings.getDataHost();
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableRegionLocator.java
@@ -16,9 +16,9 @@
 package com.google.cloud.bigtable.hbase;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.hbase.util.Logger;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -44,12 +44,12 @@ public abstract class BigtableRegionLocator extends AbstractBigtableRegionLocato
    * Constructor for BigtableRegionLocator.
    *
    * @param tableName a {@link TableName} object.
-   * @param options a {@link BigtableOptions} object.
+   * @param settings a {@link BigtableHBaseSettings} object.
    * @param client a {@link IBigtableDataClient} object.
    */
   public BigtableRegionLocator(
-      TableName tableName, BigtableOptions options, IBigtableDataClient client) {
-    super(tableName, options, client);
+      TableName tableName, BigtableHBaseSettings settings, IBigtableDataClient client) {
+    super(tableName, settings, client);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.adapters.filters.BigtableWhileMatchResultScannerAdapter;
 import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter;
@@ -26,6 +25,7 @@ import com.google.cloud.bigtable.hbase.adapters.read.GetAdapter;
 import com.google.cloud.bigtable.hbase.adapters.read.RowAdapter;
 import com.google.cloud.bigtable.hbase.adapters.read.RowRangeAdapter;
 import com.google.cloud.bigtable.hbase.adapters.read.ScanAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.Increment;
@@ -80,12 +80,12 @@ public final class Adapters {
   /**
    * createPutAdapter.
    *
-   * @param config a {@link org.apache.hadoop.conf.Configuration} object.
-   * @param options a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
+   * @param settings a {@link org.apache.hadoop.conf.Configuration} object.
    * @return a {@link com.google.cloud.bigtable.hbase.adapters.PutAdapter} object.
    */
-  public static PutAdapter createPutAdapter(Configuration config, BigtableOptions options) {
-    boolean setClientTimestamp = !options.getRetryOptions().allowRetriesWithoutTimestamp();
+  public static PutAdapter createPutAdapter(BigtableHBaseSettings settings) {
+    Configuration config = settings.getConfiguration();
+    boolean setClientTimestamp = !settings.isRetriesWithoutTimestampAllowed();
     return new PutAdapter(config.getInt("hbase.client.keyvalue.maxsize", -1), setClientTimestamp);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/HBaseRequestAdapter.java
@@ -16,7 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.data.v2.internal.NameUtil;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.MutationApi;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -26,9 +26,9 @@ import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.read.DefaultReadHooks;
 import com.google.cloud.bigtable.hbase.adapters.read.ReadHooks;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.Delete;
@@ -53,8 +53,8 @@ public class HBaseRequestAdapter {
     protected final HBaseMutationAdapter hbaseMutationAdapter;
     protected final RowMutationsAdapter rowMutationsAdapter;
 
-    public MutationAdapters(BigtableOptions options, Configuration config) {
-      this(Adapters.createPutAdapter(config, options));
+    public MutationAdapters(BigtableHBaseSettings settings) {
+      this(Adapters.createPutAdapter(settings));
     }
 
     @VisibleForTesting
@@ -76,26 +76,29 @@ public class HBaseRequestAdapter {
   /**
    * Constructor for HBaseRequestAdapter.
    *
-   * @param options a {@link com.google.cloud.bigtable.config.BigtableOptions} object.
+   * @param settings a {@link BigtableHBaseSettings} object.
    * @param tableName a {@link org.apache.hadoop.hbase.TableName} object.
-   * @param config a {@link org.apache.hadoop.conf.Configuration} object.
    */
-  public HBaseRequestAdapter(BigtableOptions options, TableName tableName, Configuration config) {
-    this(options, tableName, new MutationAdapters(options, config));
+  public HBaseRequestAdapter(BigtableHBaseSettings settings, TableName tableName) {
+    this(settings, tableName, new MutationAdapters(settings));
   }
 
   /**
    * Constructor for HBaseRequestAdapter.
    *
-   * @param options a {@link BigtableOptions} object.
+   * @param settings a {@link BigtableHBaseSettings} object.
    * @param tableName a {@link TableName} object.
    * @param mutationAdapters a {@link MutationAdapters} object.
    */
   public HBaseRequestAdapter(
-      BigtableOptions options, TableName tableName, MutationAdapters mutationAdapters) {
+      BigtableHBaseSettings settings, TableName tableName, MutationAdapters mutationAdapters) {
     this(
         tableName,
-        options.getInstanceName().toTableName(tableName.getQualifierAsString()),
+        new BigtableTableName(
+            NameUtil.formatTableName(
+                settings.getProjectId(),
+                settings.getInstanceId(),
+                tableName.getQualifierAsString())),
         mutationAdapters);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -188,7 +188,7 @@ public abstract class AbstractBigtableConnection
 
     if (locator == null) {
       locator =
-          new BigtableRegionLocator(tableName, getOptions(), getSession().getDataClientWrapper()) {
+          new BigtableRegionLocator(tableName, settings, getSession().getDataClientWrapper()) {
 
             @Override
             public SampledRowKeysAdapter getSampledRowKeysAdapter(

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -145,19 +145,18 @@ public abstract class AbstractBigtableConnection
 
     HBaseRequestAdapter adapter = createAdapter(tableName);
     ExceptionListener listener = params.getListener();
-    return new BigtableBufferedMutator(adapter, getConfiguration(), session, listener);
+    return new BigtableBufferedMutator(adapter, settings, session, listener);
   }
 
   public HBaseRequestAdapter createAdapter(TableName tableName) {
     if (mutationAdapters == null) {
       synchronized (this) {
         if (mutationAdapters == null) {
-          mutationAdapters =
-              new HBaseRequestAdapter.MutationAdapters(getOptions(), getConfiguration());
+          mutationAdapters = new HBaseRequestAdapter.MutationAdapters(settings);
         }
       }
     }
-    return new HBaseRequestAdapter(getOptions(), tableName, mutationAdapters);
+    return new HBaseRequestAdapter(settings, tableName, mutationAdapters);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutMicroBenchmark.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/PutMicroBenchmark.java
@@ -15,9 +15,10 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.CUSTOM_USER_AGENT_KEY;
+
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.bigtable.v2.MutateRowResponse;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.grpc.BigtableDataClient;
 import com.google.cloud.bigtable.grpc.BigtableDataGrpcClient;
@@ -25,6 +26,8 @@ import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableSessionSharedThreadPools;
 import com.google.cloud.bigtable.grpc.io.ChannelPool;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.classic.BigtableHBaseClassicSettings;
 import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.ManagedChannel;
@@ -41,13 +44,14 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.util.Bytes;
 
+// TODO(rahulkql): If possible move this class to bigtable-1.x-benchmark.
 public class PutMicroBenchmark {
   static final int NUM_CELLS = 10;
   private static final byte[] COLUMN_FAMILY = Bytes.toBytes("test_family");
   private static final int REAL_CHANNEL_PUT_COUNT = 100;
   private static final int FAKE_CHANNEL_PUT_COUNT = 100_000;
   private static final int VALUE_SIZE = 100;
-  private static BigtableOptions options;
+  private static BigtableHBaseSettings settings;
   private static RequestContext requestContext;
 
   public static void main(String[] args) throws Exception {
@@ -55,19 +59,15 @@ public class PutMicroBenchmark {
     String instanceId = args.length > 1 ? args[1] : "instanceId";
     String tableId = args.length > 2 ? args[2] : "table";
 
-    options =
-        BigtableOptions.builder()
-            .setProjectId(projectId)
-            .setInstanceId(instanceId)
-            .setUserAgent("put_microbenchmark")
-            .build();
+    Configuration configuration = BigtableConfiguration.configure(projectId, instanceId);
+    configuration.set(CUSTOM_USER_AGENT_KEY, "put_microbenchmark");
+    settings = BigtableHBaseSettings.create(configuration);
+
     boolean useRealConnection = args.length >= 2;
     int putCount = useRealConnection ? REAL_CHANNEL_PUT_COUNT : FAKE_CHANNEL_PUT_COUNT;
     HBaseRequestAdapter hbaseAdapter =
-        new HBaseRequestAdapter(options, TableName.valueOf(tableId), new Configuration(false));
-    requestContext =
-        RequestContext.create(
-            options.getProjectId(), options.getInstanceId(), options.getAppProfileId());
+        new HBaseRequestAdapter(settings, TableName.valueOf(tableId));
+    requestContext = RequestContext.create(settings.getProjectId(), settings.getInstanceId(), "");
 
     testCreatePuts(10_000);
 
@@ -82,7 +82,8 @@ public class PutMicroBenchmark {
   protected static ManagedChannel getChannelPool(final boolean useRealConnection)
       throws IOException, GeneralSecurityException {
     if (useRealConnection) {
-      return BigtableSession.createChannelPool(options.getDataHost(), options);
+      return BigtableSession.createChannelPool(
+          settings.getDataHost(), ((BigtableHBaseClassicSettings) settings).getBigtableOptions());
     } else {
       return new ChannelPool(createFakeChannels(), 1);
     }
@@ -129,7 +130,9 @@ public class PutMicroBenchmark {
       throws InterruptedException {
     final BigtableDataClient client =
         new BigtableDataGrpcClient(
-            cp, BigtableSessionSharedThreadPools.getInstance().getRetryExecutor(), options);
+            cp,
+            BigtableSessionSharedThreadPools.getInstance().getRetryExecutor(),
+            ((BigtableHBaseClassicSettings) settings).getBigtableOptions());
 
     Runnable r1 =
         new Runnable() {

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -15,6 +15,8 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.INSTANCE_ID_KEY;
+import static com.google.cloud.bigtable.hbase.BigtableOptionsFactory.PROJECT_ID_KEY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
@@ -26,7 +28,6 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.Query;
@@ -40,9 +41,11 @@ import com.google.cloud.bigtable.grpc.scanner.FlatRow.Cell;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.util.ByteStringer;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -123,15 +126,16 @@ public class TestBatchExecutor {
 
   private HBaseRequestAdapter requestAdapter;
 
-  private BigtableOptions options;
+  private BigtableHBaseSettings settings;
 
   @Before
-  public void setup() {
-    options =
-        BigtableOptions.builder().setProjectId("projectId").setInstanceId("instanceId").build();
-    requestAdapter =
-        new HBaseRequestAdapter(options, TableName.valueOf("table"), new Configuration(false));
+  public void setup() throws IOException {
+    Configuration configuration = new Configuration(false);
+    configuration.set(PROJECT_ID_KEY, "projectId");
+    configuration.set(INSTANCE_ID_KEY, "instanceId");
+    settings = BigtableHBaseSettings.create(configuration);
 
+    requestAdapter = new HBaseRequestAdapter(settings, TableName.valueOf("table"));
     when(mockBulkMutation.add(any(RowMutationEntry.class))).thenReturn(mockFuture);
     when(mockBigtableSession.getDataClientWrapper()).thenReturn(mockDataClient);
     when(mockDataClient.readModifyWriteRowAsync(any(ReadModifyWriteRow.class)))
@@ -237,7 +241,7 @@ public class TestBatchExecutor {
     Object[] results = new Object[2];
 
     try {
-      createExecutor(options).batch(gets, results);
+      createExecutor().batch(gets, results);
     } catch (RetriesExhaustedWithDetailsException ignored) {
     }
     Assert.assertTrue("first result is a result", results[0] instanceof Result);
@@ -253,7 +257,7 @@ public class TestBatchExecutor {
     setFuture(ImmutableList.of(response));
     final Callback<Result> callback = Mockito.mock(Callback.class);
     List<Get> gets = Arrays.asList(new Get(key));
-    createExecutor(options).batchCallback(gets, new Object[1], callback);
+    createExecutor().batchCallback(gets, new Object[1], callback);
 
     verify(callback, times(1))
         .update(
@@ -302,8 +306,7 @@ public class TestBatchExecutor {
             .build();
     when(mockFuture.get()).thenReturn(row);
 
-    BatchExecutor underTest = createExecutor(options);
-    Result[] results = underTest.batch(gets);
+    Result[] results = createExecutor().batch(gets);
     verify(mockBulkRead, times(10)).add(any(Query.class));
     verify(mockBulkRead, times(1)).flush();
     Assert.assertTrue(matchesRow(Result.EMPTY_RESULT).matches(results[0]));
@@ -330,13 +333,12 @@ public class TestBatchExecutor {
     when(mockFuture.isDone()).thenReturn(true);
   }
 
-  private BatchExecutor createExecutor(BigtableOptions options) {
-    when(mockBigtableSession.getOptions()).thenReturn(options);
-    return new BatchExecutor(mockBigtableSession, requestAdapter);
+  private BatchExecutor createExecutor() {
+    return new BatchExecutor(mockBigtableSession, settings, requestAdapter);
   }
 
   private Result[] batch(final List<? extends org.apache.hadoop.hbase.client.Row> actions)
       throws Exception {
-    return createExecutor(options).batch(actions);
+    return createExecutor().batch(actions);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
@@ -32,6 +31,7 @@ import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -95,13 +95,11 @@ public class TestBigtableBufferedMutator {
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, "project");
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "instance");
 
-    BigtableOptions options = BigtableOptionsFactory.fromConfiguration(configuration);
-    HBaseRequestAdapter adapter =
-        new HBaseRequestAdapter(options, TableName.valueOf("TABLE"), configuration);
+    BigtableHBaseSettings settings = BigtableHBaseSettings.create(configuration);
+    HBaseRequestAdapter adapter = new HBaseRequestAdapter(settings, TableName.valueOf("TABLE"));
 
     executorService = Executors.newCachedThreadPool();
-    when(mockSession.getOptions()).thenReturn(options);
-    return new BigtableBufferedMutator(adapter, configuration, mockSession, listener);
+    return new BigtableBufferedMutator(adapter, settings, mockSession, listener);
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -16,6 +16,8 @@
 package com.google.cloud.bigtable.hbase;
 
 import static com.google.cloud.bigtable.data.v2.models.Filters.FILTERS;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -87,8 +89,8 @@ public class TestBigtableTable {
   @Before
   public void setup() throws IOException {
     Configuration config = new Configuration(false);
-    config.set(BigtableOptionsFactory.PROJECT_ID_KEY, "project");
-    config.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "instance");
+    config.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT);
+    config.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE);
     config.set(BigtableOptionsFactory.BIGTABLE_ADMIN_HOST_KEY, "localhost");
     config.set(BigtableOptionsFactory.BIGTABLE_HOST_KEY, "localhost");
     config.set(BigtableOptionsFactory.BIGTABLE_PORT_KEY, "0");
@@ -101,6 +103,7 @@ public class TestBigtableTable {
     HBaseRequestAdapter hbaseAdapter = new HBaseRequestAdapter(settings, tableName);
     when(mockConnection.getConfiguration()).thenReturn(config);
     when(mockConnection.getSession()).thenReturn(mockSession);
+    when(mockConnection.getBigtableHBaseSettings()).thenReturn(settings);
     when(mockSession.getDataClientWrapper()).thenReturn(mockBigtableDataClient);
     when(mockBigtableDataClient.readFlatRows(isA(Query.class))).thenReturn(mockResultScanner);
     table = new AbstractBigtableTable(mockConnection, hbaseAdapter) {};
@@ -239,5 +242,14 @@ public class TestBigtableTable {
 
     verify(mockBigtableDataClient).readFlatRows(isA(Query.class));
     verify(mockResultScanner).next();
+  }
+
+  @Test
+  public void testToString() {
+    String abstractTableToStr = table.toString();
+    assertThat(abstractTableToStr, containsString("project=" + TEST_PROJECT));
+    assertThat(abstractTableToStr, containsString("instance=" + TEST_INSTANCE));
+    assertThat(abstractTableToStr, containsString("table=" + TEST_TABLE));
+    assertThat(abstractTableToStr, containsString("host=" + "localhost"));
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
@@ -21,6 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.hbase.BigtableBufferedMutatorHelper;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -43,12 +44,12 @@ public class BigtableAsyncBufferedMutator implements AsyncBufferedMutator {
    * Constructor for BigtableBufferedMutator.
    *
    * @param adapter Converts HBase objects to Bigtable protos
-   * @param configuration For Additional configuration. TODO: move this to options
+   * @param settings For bigtable settings.
    * @param session a {@link com.google.cloud.bigtable.grpc.BigtableSession}
    */
   public BigtableAsyncBufferedMutator(
-      HBaseRequestAdapter adapter, Configuration configuration, BigtableSession session) {
-    helper = new BigtableBufferedMutatorHelper(adapter, configuration, session);
+      HBaseRequestAdapter adapter, BigtableHBaseSettings settings, BigtableSession session) {
+    helper = new BigtableBufferedMutatorHelper(adapter, settings, session);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -92,7 +92,9 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
 
   protected synchronized BatchExecutor getBatchExecutor() {
     if (batchExecutor == null) {
-      batchExecutor = new BatchExecutor(connection.getSession(), hbaseAdapter);
+      batchExecutor =
+          new BatchExecutor(
+              connection.getSession(), connection.getBigtableHBaseSettings(), hbaseAdapter);
     }
     return batchExecutor;
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
@@ -16,10 +16,10 @@
 package com.google.cloud.bigtable.hbase2_x;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.hbase.AbstractBigtableRegionLocator;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.HRegionLocation;
@@ -40,8 +40,8 @@ public class BigtableAsyncTableRegionLocator extends AbstractBigtableRegionLocat
   HRegionLocation hRegionLocation = null;
 
   public BigtableAsyncTableRegionLocator(
-      TableName tableName, BigtableOptions options, IBigtableDataClient client) {
-    super(tableName, options, client);
+      TableName tableName, BigtableHBaseSettings settings, IBigtableDataClient client) {
+    super(tableName, settings, client);
   }
 
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -311,8 +311,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
   @Override
   public AsyncTableRegionLocator getRegionLocator(TableName tableName) {
-    return new BigtableAsyncTableRegionLocator(
-        tableName, getOptions(), this.session.getDataClientWrapper());
+    return new BigtableAsyncTableRegionLocator(tableName, settings, session.getDataClientWrapper());
   }
 
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -99,12 +99,11 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
     if (mutationAdapters == null) {
       synchronized (this) {
         if (mutationAdapters == null) {
-          mutationAdapters =
-              new HBaseRequestAdapter.MutationAdapters(getOptions(), getConfiguration());
+          mutationAdapters = new HBaseRequestAdapter.MutationAdapters(settings);
         }
       }
     }
-    return new HBaseRequestAdapter(getOptions(), tableName, mutationAdapters);
+    return new HBaseRequestAdapter(settings, tableName, mutationAdapters);
   }
 
   public BigtableSession getSession() {
@@ -233,8 +232,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
       @Override
       public AsyncBufferedMutator build() {
-        return new BigtableAsyncBufferedMutator(
-            createAdapter(tableName), getConfiguration(), session);
+        return new BigtableAsyncBufferedMutator(createAdapter(tableName), settings, session);
       }
     };
   }


### PR DESCRIPTION
This change updates `AbstractBigtableRegionLocator` and `AbstractBigtableTable` and it's references.