### PR TITLE
chore: part 2 of replacing IBigtableDataClient with DataClientWrapper

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase.adapters;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.adapters.filters.BigtableWhileMatchResultScannerAdapter;
 import com.google.cloud.bigtable.hbase.adapters.filters.FilterAdapter;
 import com.google.cloud.bigtable.hbase.adapters.read.BigtableResultScannerAdapter;
@@ -54,12 +53,12 @@ public final class Adapters {
   /** Constant <code>SCAN_ADAPTER</code> */
   public static final ScanAdapter SCAN_ADAPTER = new ScanAdapter(FILTER_ADAPTER, ROW_RANGE_ADAPTER);
   /** Constant <code>BIGTABLE_RESULT_SCAN_ADAPTER</code> */
-  public static final BigtableResultScannerAdapter<FlatRow> BIGTABLE_RESULT_SCAN_ADAPTER =
-      new BigtableResultScannerAdapter<>(FLAT_ROW_ADAPTER);
+  public static final BigtableResultScannerAdapter BIGTABLE_RESULT_SCAN_ADAPTER =
+      new BigtableResultScannerAdapter();
   /** Constant <code>BIGTABLE_WHILE_MATCH_RESULT_RESULT_SCAN_ADAPTER</code> */
   public static final BigtableWhileMatchResultScannerAdapter
       BIGTABLE_WHILE_MATCH_RESULT_RESULT_SCAN_ADAPTER =
-          new BigtableWhileMatchResultScannerAdapter(FLAT_ROW_ADAPTER);
+          new BigtableWhileMatchResultScannerAdapter();
   /** Constant <code>GET_ADAPTER</code> */
   public static final GetAdapter GET_ADAPTER = new GetAdapter(SCAN_ADAPTER);
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/BigtableResultScannerAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/BigtableResultScannerAdapter.java
@@ -16,7 +16,6 @@
 package com.google.cloud.bigtable.hbase.adapters.read;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.hbase.adapters.ResponseAdapter;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
 import java.io.IOException;
@@ -30,18 +29,7 @@ import org.apache.hadoop.hbase.client.ResultScanner;
  * <p>For internal use only - public for technical reasons.
  */
 @InternalApi("For internal usage only")
-public class BigtableResultScannerAdapter<T> {
-
-  private final ResponseAdapter<T, Result> rowAdapter;
-
-  /**
-   * Constructor for BigtableResultScannerAdapter.
-   *
-   * @param rowAdapter a {@link com.google.cloud.bigtable.hbase.adapters.ResponseAdapter} object.
-   */
-  public BigtableResultScannerAdapter(ResponseAdapter<T, Result> rowAdapter) {
-    this.rowAdapter = rowAdapter;
-  }
+public class BigtableResultScannerAdapter {
 
   /**
    * adapt.
@@ -53,21 +41,21 @@ public class BigtableResultScannerAdapter<T> {
    * @return a {@link org.apache.hadoop.hbase.client.ResultScanner} object.
    */
   public ResultScanner adapt(
-      final com.google.cloud.bigtable.grpc.scanner.ResultScanner<T> bigtableResultScanner,
+      final com.google.cloud.bigtable.grpc.scanner.ResultScanner<Result> bigtableResultScanner,
       final Span span) {
     return new AbstractClientScanner() {
       int rowCount = 0;
 
       @Override
       public Result next() throws IOException {
-        T row = bigtableResultScanner.next();
+        Result row = bigtableResultScanner.next();
         if (row == null) {
           // Null signals EOF.
           span.end();
           return null;
         }
         rowCount++;
-        return rowAdapter.adaptResponse(row);
+        return row;
       }
 
       @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/DataClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/DataClientClassicApi.java
@@ -68,7 +68,7 @@ public class DataClientClassicApi implements DataClientWrapper {
   private final BigtableDataClient delegate;
   private final RequestContext requestContext;
 
-  DataClientClassicApi(BigtableSession session, RequestContext requestContext) {
+  public DataClientClassicApi(BigtableSession session, RequestContext requestContext) {
     this.session = session;
     this.delegate = session.getDataClient();
     this.requestContext = requestContext;

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestBigtableWhileMatchResultScannerAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestBigtableWhileMatchResultScannerAdapter.java
@@ -17,20 +17,18 @@ package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.google.cloud.bigtable.grpc.scanner.FlatRow;
-import com.google.cloud.bigtable.hbase.adapters.ResponseAdapter;
-import com.google.protobuf.ByteString;
+import com.google.cloud.bigtable.hbase.adapters.read.RowCell;
+import com.google.common.collect.ImmutableList;
 import io.opencensus.trace.Span;
 import java.io.IOException;
-import java.util.Arrays;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,9 +43,7 @@ import org.mockito.junit.MockitoRule;
 public class TestBigtableWhileMatchResultScannerAdapter {
   @Rule public final MockitoRule mockitoRule = MockitoJUnit.rule();
 
-  @Mock private ResponseAdapter<FlatRow, Result> mockRowAdapter;
-
-  @Mock com.google.cloud.bigtable.grpc.scanner.ResultScanner<FlatRow> mockBigtableResultScanner;
+  @Mock com.google.cloud.bigtable.grpc.scanner.ResultScanner<Result> mockBigtableResultScanner;
 
   @Mock Span mockSpan;
 
@@ -55,7 +51,7 @@ public class TestBigtableWhileMatchResultScannerAdapter {
 
   @Before
   public void setUp() {
-    adapter = new BigtableWhileMatchResultScannerAdapter(mockRowAdapter);
+    adapter = new BigtableWhileMatchResultScannerAdapter();
   }
 
   @Test
@@ -65,56 +61,72 @@ public class TestBigtableWhileMatchResultScannerAdapter {
     ResultScanner scanner = adapter.adapt(mockBigtableResultScanner, mockSpan);
     assertNull(scanner.next());
     verify(mockBigtableResultScanner).next();
-    verifyNoInteractions(mockRowAdapter);
     verify(mockSpan, times(1)).end();
   }
 
   @Test
   public void adapt_oneRow() throws IOException {
-    FlatRow row = FlatRow.newBuilder().withRowKey(ByteString.copyFromUtf8("key")).build();
-    when(mockBigtableResultScanner.next()).thenReturn(row);
-    Result result = new Result();
-    when(mockRowAdapter.adaptResponse(same(row))).thenReturn(result);
+    Result expectedResult =
+        Result.create(
+            ImmutableList.<Cell>of(
+                new RowCell(
+                    Bytes.toBytes("row"),
+                    Bytes.toBytes("family"),
+                    Bytes.toBytes("q"),
+                    10000L,
+                    Bytes.toBytes("value"))));
+    when(mockBigtableResultScanner.next()).thenReturn(expectedResult);
 
     ResultScanner scanner = adapter.adapt(mockBigtableResultScanner, mockSpan);
-    assertSame(result, scanner.next());
+    assertSame(expectedResult, scanner.next());
     verify(mockBigtableResultScanner).next();
-    verify(mockRowAdapter).adaptResponse(same(row));
     verify(mockSpan, times(0)).end();
   }
 
   @Test
   public void adapt_oneRow_hasMatchingLabels() throws IOException {
-    FlatRow row =
-        FlatRow.newBuilder()
-            .withRowKey(ByteString.copyFromUtf8("key"))
-            .addCell("", ByteString.EMPTY, 0, ByteString.EMPTY, Arrays.asList("a-in"))
-            .addCell("", ByteString.EMPTY, 0, ByteString.EMPTY, Arrays.asList("a-out"))
-            .build();
-    when(mockBigtableResultScanner.next()).thenReturn(row);
-    Result result = new Result();
-    when(mockRowAdapter.adaptResponse(same(row))).thenReturn(result);
 
+    Result expectedResult =
+        Result.create(
+            ImmutableList.<Cell>of(
+                new RowCell(
+                    Bytes.toBytes("row"),
+                    Bytes.toBytes("family"),
+                    Bytes.toBytes("q"),
+                    10000L,
+                    Bytes.toBytes("value"),
+                    ImmutableList.of("a-in")),
+                new RowCell(
+                    Bytes.toBytes("row"),
+                    Bytes.toBytes("family"),
+                    Bytes.toBytes("q"),
+                    10000L,
+                    Bytes.toBytes("value"),
+                    ImmutableList.of("a-out"))));
+    when(mockBigtableResultScanner.next()).thenReturn(expectedResult);
     ResultScanner scanner = adapter.adapt(mockBigtableResultScanner, mockSpan);
-    assertSame(result, scanner.next());
+    assertSame(expectedResult, scanner.next());
     verify(mockBigtableResultScanner).next();
-    verify(mockRowAdapter).adaptResponse(same(row));
     verify(mockSpan, times(0)).end();
   }
 
   @Test
   public void adapt_oneRow_hasNoMatchingLabels() throws IOException {
-    FlatRow row =
-        FlatRow.newBuilder()
-            .withRowKey(ByteString.copyFromUtf8("key"))
-            .addCell("", ByteString.EMPTY, 0, ByteString.EMPTY, Arrays.asList("a-in"))
-            .build();
-    when(mockBigtableResultScanner.next()).thenReturn(row);
+    Result expectedResult =
+        Result.create(
+            ImmutableList.<Cell>of(
+                new RowCell(
+                    Bytes.toBytes("key"),
+                    Bytes.toBytes("family"),
+                    Bytes.toBytes("q"),
+                    10000L,
+                    Bytes.toBytes("value"),
+                    ImmutableList.of("a-out"))));
+    when(mockBigtableResultScanner.next()).thenReturn(expectedResult);
 
     ResultScanner scanner = adapter.adapt(mockBigtableResultScanner, mockSpan);
     assertNull(scanner.next());
     verify(mockSpan, times(1)).end();
     verify(mockBigtableResultScanner).next();
-    verifyNoInteractions(mockRowAdapter);
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestBigtableWhileMatchResultScannerAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/filters/TestBigtableWhileMatchResultScannerAdapter.java
@@ -15,8 +15,9 @@
  */
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -74,11 +75,12 @@ public class TestBigtableWhileMatchResultScannerAdapter {
                     Bytes.toBytes("family"),
                     Bytes.toBytes("q"),
                     10000L,
-                    Bytes.toBytes("value"))));
+                    Bytes.toBytes("value"),
+                    ImmutableList.<String>of())));
     when(mockBigtableResultScanner.next()).thenReturn(expectedResult);
 
     ResultScanner scanner = adapter.adapt(mockBigtableResultScanner, mockSpan);
-    assertSame(expectedResult, scanner.next());
+    assertArrayEquals(expectedResult.rawCells(), scanner.next().rawCells());
     verify(mockBigtableResultScanner).next();
     verify(mockSpan, times(0)).end();
   }
@@ -104,8 +106,9 @@ public class TestBigtableWhileMatchResultScannerAdapter {
                     Bytes.toBytes("value"),
                     ImmutableList.of("a-out"))));
     when(mockBigtableResultScanner.next()).thenReturn(expectedResult);
+
     ResultScanner scanner = adapter.adapt(mockBigtableResultScanner, mockSpan);
-    assertSame(expectedResult, scanner.next());
+    assertEquals(0, scanner.next().size());
     verify(mockBigtableResultScanner).next();
     verify(mockSpan, times(0)).end();
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestFlatRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/read/TestFlatRowAdapter.java
@@ -52,7 +52,7 @@ public class TestFlatRowAdapter {
 
     // The rowKey is defined based on the cells, and in this case there are no cells, so there isn't
     // a key.
-    assertEquals(null, instance.adaptToRow(result));
+    assertNull(instance.adaptToRow(result));
   }
 
   @Test
@@ -74,12 +74,11 @@ public class TestFlatRowAdapter {
             .addCell(family1, ByteString.copyFrom(qualifier1), 54321L, ByteString.copyFrom(value1))
             // Same family, same column, but different timestamps.
             .addCell(family1, ByteString.copyFrom(qualifier1), 12345L, ByteString.copyFrom(value2))
-            // With label
             .addCell(
                 family1,
                 ByteString.copyFrom(qualifier1),
                 12345L,
-                ByteString.copyFrom(value2),
+                ByteString.copyFrom(value3),
                 Arrays.asList("label"))
             // Same family, same timestamp, but different column.
             .addCell(family1, ByteString.copyFrom(qualifier2), 54321L, ByteString.copyFrom(value3))
@@ -87,33 +86,32 @@ public class TestFlatRowAdapter {
             .addCell(family2, ByteString.copyFrom(qualifier1), 54321L, ByteString.copyFrom(value4))
             // Same timestamp, but different family qualifier2 column.
             .addCell(family2, ByteString.copyFrom(qualifier2), 54321L, ByteString.copyFrom(value5))
+            // With label
+
             .build();
 
     Result result = instance.adaptResponse(row);
-    assertEquals(5, result.rawCells().length);
+    assertEquals(6, result.rawCells().length);
 
-    List<org.apache.hadoop.hbase.Cell> cells1 =
-        result.getColumnCells(family1.getBytes(), qualifier1);
-    assertEquals(2, cells1.size());
+    List<Cell> cells1 = result.getColumnCells(family1.getBytes(), qualifier1);
+    assertEquals(3, cells1.size());
     assertEquals(Bytes.toString(value1), Bytes.toString(CellUtil.cloneValue(cells1.get(0))));
     assertEquals(Bytes.toString(value2), Bytes.toString(CellUtil.cloneValue(cells1.get(1))));
+    assertEquals(Bytes.toString(value3), Bytes.toString(CellUtil.cloneValue(cells1.get(2))));
 
-    List<org.apache.hadoop.hbase.Cell> cells2 =
-        result.getColumnCells(family1.getBytes(), qualifier2);
+    List<Cell> cells2 = result.getColumnCells(family1.getBytes(), qualifier2);
     assertEquals(1, cells2.size());
     assertEquals(Bytes.toString(value3), Bytes.toString(CellUtil.cloneValue(cells2.get(0))));
 
-    List<org.apache.hadoop.hbase.Cell> cells3 =
-        result.getColumnCells(family2.getBytes(), qualifier1);
+    List<Cell> cells3 = result.getColumnCells(family2.getBytes(), qualifier1);
     assertEquals(1, cells3.size());
     assertEquals(Bytes.toString(value4), Bytes.toString(CellUtil.cloneValue(cells3.get(0))));
 
-    List<org.apache.hadoop.hbase.Cell> cells4 =
-        result.getColumnCells(family2.getBytes(), qualifier2);
+    List<Cell> cells4 = result.getColumnCells(family2.getBytes(), qualifier2);
     assertEquals(1, cells4.size());
     assertEquals(Bytes.toString(value5), Bytes.toString(CellUtil.cloneValue(cells4.get(0))));
 
-    // The duplicate row and label cells have been removed. The timestamp micros get converted to
+    // The duplicate row have been removed. The timestamp micros get converted to
     // millisecond accuracy.
     FlatRow expected =
         FlatRow.newBuilder()
@@ -122,6 +120,13 @@ public class TestFlatRowAdapter {
             .addCell(family1, ByteString.copyFrom(qualifier1), 54000L, ByteString.copyFrom(value1))
             // Same family, same column, but different timestamps.
             .addCell(family1, ByteString.copyFrom(qualifier1), 12000L, ByteString.copyFrom(value2))
+            // with Labels
+            .addCell(
+                family1,
+                ByteString.copyFrom(qualifier1),
+                12000L,
+                ByteString.copyFrom(value3),
+                Arrays.asList("label"))
             // Same family, same timestamp, but different column.
             .addCell(family1, ByteString.copyFrom(qualifier2), 54000L, ByteString.copyFrom(value3))
             // Same column, same timestamp, but different family.

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -19,10 +19,10 @@ import static com.google.cloud.bigtable.hbase2_x.FutureUtils.toCompletableFuture
 import static java.util.stream.Collectors.toList;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.core.IBigtableDataClient;
+import com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.Query;
-import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.hbase.AbstractBigtableTable;
 import com.google.cloud.bigtable.hbase.BatchExecutor;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
@@ -30,6 +30,8 @@ import com.google.cloud.bigtable.hbase.adapters.CheckAndMutateUtil;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.adapters.read.GetAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.classic.DataClientClassicApi;
 import com.google.common.base.Preconditions;
 import io.grpc.stub.StreamObserver;
 import io.opencensus.common.Scope;
@@ -78,16 +80,21 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
   }
 
   private final CommonConnection connection;
-  private final IBigtableDataClient clientWrapper;
+  private final DataClientWrapper clientWrapper;
   private final HBaseRequestAdapter hbaseAdapter;
   private final TableName tableName;
   private BatchExecutor batchExecutor;
 
   public BigtableAsyncTable(CommonConnection connection, HBaseRequestAdapter hbaseAdapter) {
     this.connection = connection;
-    this.clientWrapper = connection.getSession().getDataClientWrapper();
     this.hbaseAdapter = hbaseAdapter;
     this.tableName = hbaseAdapter.getTableName();
+    BigtableOptions options = connection.getOptions();
+    this.clientWrapper =
+        new DataClientClassicApi(
+            connection.getSession(),
+            RequestContext.create(
+                options.getProjectId(), options.getInstanceId(), options.getAppProfileId()));
   }
 
   protected synchronized BatchExecutor getBatchExecutor() {
@@ -103,9 +110,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
   @Override
   public CompletableFuture<Result> append(Append append) {
     return toCompletableFuture(clientWrapper.readModifyWriteRowAsync(hbaseAdapter.adapt(append)))
-        .thenApply(
-            response ->
-                append.isReturnResults() ? Adapters.ROW_ADAPTER.adaptResponse(response) : null);
+        .thenApply(response -> append.isReturnResults() ? response : null);
   }
 
   /** {@inheritDoc} */
@@ -125,10 +130,10 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
   static final class CheckAndMutateBuilderImpl implements CheckAndMutateBuilder {
 
     private final CheckAndMutateUtil.RequestBuilder builder;
-    private final IBigtableDataClient clientWrapper;
+    private final DataClientWrapper clientWrapper;
 
     public CheckAndMutateBuilderImpl(
-        IBigtableDataClient clientWrapper,
+        DataClientWrapper clientWrapper,
         HBaseRequestAdapter hbaseAdapter,
         byte[] row,
         byte[] family) {
@@ -229,21 +234,17 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
   /** {@inheritDoc} */
   @Override
   public CompletableFuture<Result> get(Get get) {
-    return toCompletableFuture(clientWrapper.readFlatRowsAsync(hbaseAdapter.adapt(get)))
-        .thenApply(BigtableAsyncTable::toResult);
+    return toCompletableFuture(clientWrapper.readRowsAsync(hbaseAdapter.adapt(get)))
+        .thenApply(BigtableAsyncTable::getSingleResult);
   }
 
   /** {@inheritDoc} */
   @Override
   public CompletableFuture<Boolean> exists(Get get) {
-    return get(GetAdapter.setCheckExistenceOnly(get)).thenApply(r -> !r.isEmpty());
+    return get(GetAdapter.setCheckExistenceOnly(get)).thenApply(r -> r != null && !r.isEmpty());
   }
 
-  private static Result toResult(List<FlatRow> list) {
-    return Adapters.FLAT_ROW_ADAPTER.adaptResponse(getSingleResult(list));
-  }
-
-  private static FlatRow getSingleResult(List<FlatRow> list) {
+  private static Result getSingleResult(List<Result> list) {
     switch (list.size()) {
       case 0:
         return null;
@@ -308,8 +309,8 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
   /** {@inheritDoc} */
   @Override
   public CompletableFuture<Result> increment(Increment increment) {
-    return toCompletableFuture(clientWrapper.readModifyWriteRowAsync(hbaseAdapter.adapt(increment)))
-        .thenApply(Adapters.ROW_ADAPTER::adaptResponse);
+    return toCompletableFuture(
+        clientWrapper.readModifyWriteRowAsync(hbaseAdapter.adapt(increment)));
   }
 
   /** {@inheritDoc} */
@@ -337,8 +338,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
     if (AbstractBigtableTable.hasWhileMatchFilter(scan.getFilter())) {
       throw new UnsupportedOperationException("scanAll with while match filter is not allowed");
     }
-    return toCompletableFuture(clientWrapper.readFlatRowsAsync(hbaseAdapter.adapt(scan)))
-        .thenApply(list -> map(list, Adapters.FLAT_ROW_ADAPTER::adaptResponse));
+    return toCompletableFuture(clientWrapper.readRowsAsync(hbaseAdapter.adapt(scan)));
   }
 
   /** {@inheritDoc} */
@@ -347,8 +347,8 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
     LOG.trace("getScanner(Scan)");
     final Span span = TRACER.spanBuilder("BigtableTable.scan").startSpan();
     try (Scope scope = TRACER.withSpan(span)) {
-      com.google.cloud.bigtable.grpc.scanner.ResultScanner<FlatRow> scanner =
-          clientWrapper.readFlatRows(hbaseAdapter.adapt(scan));
+      com.google.cloud.bigtable.grpc.scanner.ResultScanner<Result> scanner =
+          clientWrapper.readRows(hbaseAdapter.adapt(scan));
       if (AbstractBigtableTable.hasWhileMatchFilter(scan.getFilter())) {
         return Adapters.BIGTABLE_WHILE_MATCH_RESULT_RESULT_SCAN_ADAPTER.adapt(scanner, span);
       }
@@ -388,12 +388,12 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
           "scan with consumer and while match filter is not allowed");
     }
     Query query = hbaseAdapter.adapt(scan);
-    clientWrapper.readFlatRowsAsync(
+    clientWrapper.readRowsAsync(
         query,
-        new StreamObserver<FlatRow>() {
+        new StreamObserver<Result>() {
           @Override
-          public void onNext(FlatRow value) {
-            consumer.onNext(Adapters.FLAT_ROW_ADAPTER.adaptResponse(value));
+          public void onNext(Result value) {
+            consumer.onNext(value);
           }
 
           @Override


### PR DESCRIPTION
This change updates AbstractBigtable with read operation along with  `BigtableWhileMatchResultScannerAdapter` and `BigtableResultScannerAdapter`.