### PR TITLE
chore(fix): add small fixes for BigtableConnection

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -275,11 +275,7 @@ public abstract class AbstractBigtableTable implements Table {
   }
 
   protected Result convertToResult(FlatRow row) {
-    if (row == null) {
-      return Adapters.FLAT_ROW_ADAPTER.adaptResponse(null);
-    } else {
-      return Adapters.FLAT_ROW_ADAPTER.adaptResponse(row);
-    }
+    return Adapters.FLAT_ROW_ADAPTER.adaptResponse(row);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/FlatRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/FlatRowAdapter.java
@@ -73,38 +73,4 @@ public class FlatRowAdapter implements ResponseAdapter<FlatRow, Result> {
         TimestampConverter.bigtable2hbase(cell.getTimestamp()),
         ByteStringer.extract(cell.getValue()));
   }
-
-  /**
-   * Convert a {@link org.apache.hadoop.hbase.client.Result} to a {@link FlatRow}.
-   *
-   * @param result a {@link org.apache.hadoop.hbase.client.Result} object.
-   * @return a {@link FlatRow} object.
-   */
-  public FlatRow adaptToRow(Result result) {
-    // Result.getRow() is derived from its cells.  If the cells are empty, the row will be null.
-    if (result.getRow() == null) {
-      return null;
-    }
-
-    FlatRow.Builder rowBuilder =
-        FlatRow.newBuilder().withRowKey(ByteStringer.wrap(result.getRow()));
-
-    final Cell[] rawCells = result.rawCells();
-    if (rawCells != null && rawCells.length > 0) {
-      for (Cell rawCell : rawCells) {
-        rowBuilder.addCell(
-            Bytes.toString(
-                rawCell.getFamilyArray(), rawCell.getFamilyOffset(), rawCell.getFamilyLength()),
-            ByteStringer.wrap(
-                rawCell.getQualifierArray(),
-                rawCell.getQualifierOffset(),
-                rawCell.getQualifierLength()),
-            TimestampConverter.hbase2bigtable(rawCell.getTimestamp()),
-            ByteStringer.wrap(
-                rawCell.getValueArray(), rawCell.getValueOffset(), rawCell.getValueLength()));
-      }
-    }
-
-    return rowBuilder.build();
-  }
 }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
@@ -105,5 +105,31 @@ limitations under the License.
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-bigtable-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/pom.xml
@@ -92,6 +92,35 @@ limitations under the License.
       <version>${dropwizard.metrics.version}</version>
     </dependency>
 
+    <!-- These are direct dependencies of TestBigtableConnection.java which is in test scope,
+     but they are transitive dependencies of bigtable-client-core, which needs them during runtime.
+     For more information please see https://github.com/googleapis/java-bigtable-hbase/pull/2447 -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-stub</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-bigtable-v2</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-bigtable</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
     <!-- Test dependencies-->
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
@@ -103,32 +132,6 @@ limitations under the License.
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>${junit.version}</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-stub</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>proto-google-cloud-bigtable-v2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-bigtable</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.api.grpc</groupId>
-      <artifactId>grpc-google-cloud-bigtable-v2</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableConnection.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableConnection.java
@@ -18,8 +18,8 @@ package com.google.cloud.bigtable.hbase1_x;
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.hbase.AbstractBigtableTable;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.apache.hadoop.conf.Configuration;
@@ -79,10 +79,10 @@ public class BigtableConnection extends AbstractBigtableConnection {
 
   @Override
   public List<HRegionInfo> getAllRegionInfos(TableName tableName) throws IOException {
-    List<HRegionInfo> regionInfos = Collections.emptyList();
+    ImmutableList.Builder<HRegionInfo> regionInfos = ImmutableList.builder();
     for (HRegionLocation location : getRegionLocator(tableName).getAllRegionLocations()) {
       regionInfos.add(location.getRegionInfo());
     }
-    return regionInfos;
+    return regionInfos.build();
   }
 }

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableConnection.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableConnection.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.hbase1_x;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.bigtable.v2.BigtableGrpc;
+import com.google.bigtable.v2.SampleRowKeysRequest;
+import com.google.bigtable.v2.SampleRowKeysResponse;
+import com.google.cloud.bigtable.data.v2.internal.NameUtil;
+import com.google.cloud.bigtable.hbase.AbstractBigtableTable;
+import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
+import com.google.common.collect.Queues;
+import com.google.protobuf.ByteString;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestBigtableConnection {
+
+  private static final String TEST_PROJECT_ID = "fake-project-id";
+  private static final String TEST_INSTANCE_ID = "fake-instance-id";
+  private static final TableName TABLE_NAME = TableName.valueOf("test-table");
+  private static final String FULL_TABLE_NAME =
+      NameUtil.formatTableName(TEST_PROJECT_ID, TEST_INSTANCE_ID, TABLE_NAME.getNameAsString());
+  private static Server server;
+  private static int dataPort;
+
+  private static FakeDataService fakeDataService = new FakeDataService();
+  private BigtableConnection connection;
+
+  @BeforeClass
+  public static void setUpServer() throws IOException {
+    try (ServerSocket s = new ServerSocket(0)) {
+      dataPort = s.getLocalPort();
+    }
+    server = ServerBuilder.forPort(dataPort).addService(fakeDataService).build();
+    server.start();
+  }
+
+  @AfterClass
+  public static void tearDownServer() throws InterruptedException {
+    if (server != null) {
+      server.shutdownNow();
+      server.awaitTermination();
+    }
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    Configuration configuration = new Configuration(false);
+    configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
+    configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
+    configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
+    configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + dataPort);
+    connection = new BigtableConnection(configuration);
+  }
+
+  @Test
+  public void testGetters() throws IOException {
+    assertTrue(connection.getAdmin() instanceof BigtableAdmin);
+    assertTrue(
+        connection.getTable(TABLE_NAME, Executors.newSingleThreadExecutor())
+            instanceof AbstractBigtableTable);
+    assertTrue(connection.getDisabledTables().isEmpty());
+  }
+
+  @Test
+  public void testAllRegions() throws IOException, InterruptedException {
+    List<HRegionInfo> regionInfoList = connection.getAllRegionInfos(TABLE_NAME);
+
+    SampleRowKeysRequest request = fakeDataService.popLastRequest();
+    assertEquals(FULL_TABLE_NAME, request.getTableName());
+
+    assertEquals("", Bytes.toString(regionInfoList.get(0).getStartKey()));
+    assertEquals("rowKey", Bytes.toString(regionInfoList.get(0).getEndKey()));
+  }
+
+  private static class FakeDataService extends BigtableGrpc.BigtableImplBase {
+    final BlockingQueue<Object> requests = Queues.newLinkedBlockingDeque();
+
+    @SuppressWarnings("unchecked")
+    <T> T popLastRequest() throws InterruptedException {
+      return (T) requests.poll(1, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void sampleRowKeys(
+        SampleRowKeysRequest request, StreamObserver<SampleRowKeysResponse> responseObserver) {
+      requests.add(request);
+      responseObserver.onNext(
+          SampleRowKeysResponse.newBuilder()
+              .setRowKey(ByteString.copyFromUtf8("rowKey"))
+              .setOffsetBytes(10000L)
+              .build());
+      responseObserver.onCompleted();
+    }
+  }
+}

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableConnection.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/test/java/com/google/cloud/bigtable/hbase1_x/TestBigtableConnection.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -58,6 +59,7 @@ public class TestBigtableConnection {
   private static int dataPort;
 
   private static FakeDataService fakeDataService = new FakeDataService();
+  private Configuration configuration;
   private BigtableConnection connection;
 
   @BeforeClass
@@ -79,13 +81,22 @@ public class TestBigtableConnection {
 
   @Before
   public void setUp() throws IOException {
-    Configuration configuration = new Configuration(false);
+    configuration = new Configuration(false);
     configuration.set(BigtableOptionsFactory.PROJECT_ID_KEY, TEST_PROJECT_ID);
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, TEST_INSTANCE_ID);
     configuration.set(BigtableOptionsFactory.BIGTABLE_NULL_CREDENTIAL_ENABLE_KEY, "true");
     configuration.set(BigtableOptionsFactory.BIGTABLE_DATA_CHANNEL_COUNT_KEY, "1");
     configuration.set(BigtableOptionsFactory.BIGTABLE_EMULATOR_HOST_KEY, "localhost:" + dataPort);
     connection = new BigtableConnection(configuration);
+  }
+
+  @Test
+  public void testOverloadedConstructor() throws IOException {
+    Connection hbaseConnection =
+        new BigtableConnection(configuration, false, Executors.newSingleThreadExecutor(), null);
+
+    assertTrue(hbaseConnection.getAdmin() instanceof BigtableAdmin);
+    assertTrue(hbaseConnection.getTable(TABLE_NAME) instanceof AbstractBigtableTable);
   }
 
   @Test

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -317,7 +317,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
   @Override
   public void clearRegionLocationCache() {
-    throw new UnsupportedOperationException("this ddoes not supported yet");
+    throw new UnsupportedOperationException("clearRegionLocationCache is not supported.");
   }
 
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/test/java/com/google/cloud/bigtable/hbase2_x/adapters/admin/TestTableAdapter2x.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.cloud.bigtable.hbase.com.google.cloud.bigtable.hbase2_x.adapters.admin;
+package com.google.cloud.bigtable.hbase2_x.adapters.admin;
 
 import static com.google.cloud.bigtable.admin.v2.models.GCRules.GCRULES;
 
@@ -22,7 +22,6 @@ import com.google.bigtable.admin.v2.Table;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.GCRules;
 import com.google.cloud.bigtable.hbase.adapters.admin.TableAdapter;
-import com.google.cloud.bigtable.hbase2_x.adapters.admin.TableAdapter2x;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;


### PR DESCRIPTION
This change contains following small fixes:
 - Fix for BigtableConnection#getAllRegionInfos and unit test case for the same.
 - Small fix for AbstractBigtableTable.
 - Moved TestTableAdapter2x class to appropriate package.
 - Added dependencies used for performing test.