### PR TITLE
chore: replacing Data Client with new wrappers (Part-3)

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/Adapters.java
@@ -59,7 +59,7 @@ public final class Adapters {
   /** Constant <code>BIGTABLE_WHILE_MATCH_RESULT_RESULT_SCAN_ADAPTER</code> */
   public static final BigtableWhileMatchResultScannerAdapter
       BIGTABLE_WHILE_MATCH_RESULT_RESULT_SCAN_ADAPTER =
-          new BigtableWhileMatchResultScannerAdapter(FLAT_ROW_ADAPTER);
+          new BigtableWhileMatchResultScannerAdapter();
   /** Constant <code>GET_ADAPTER</code> */
   public static final GetAdapter GET_ADAPTER = new GetAdapter(SCAN_ADAPTER);
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableWhileMatchResultScannerAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/filters/BigtableWhileMatchResultScannerAdapter.java
@@ -16,11 +16,12 @@
 package com.google.cloud.bigtable.hbase.adapters.filters;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.grpc.scanner.FlatRow;
-import com.google.cloud.bigtable.hbase.adapters.ResponseAdapter;
+import com.google.cloud.bigtable.hbase.adapters.read.RowCell;
+import com.google.common.collect.ImmutableList;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
 import java.io.IOException;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.AbstractClientScanner;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -38,17 +39,6 @@ public class BigtableWhileMatchResultScannerAdapter {
   private static final String WHILE_MATCH_FILTER_IN_LABEL_SUFFIX = "-in";
   private static final String WHILE_MATCH_FILTER_OUT_LABEL_SUFFIX = "-out";
 
-  private final ResponseAdapter<FlatRow, Result> rowAdapter;
-
-  /**
-   * Constructor for BigtableWhileMatchResultScannerAdapter.
-   *
-   * @param rowAdapter a {@link com.google.cloud.bigtable.hbase.adapters.ResponseAdapter} object.
-   */
-  public BigtableWhileMatchResultScannerAdapter(ResponseAdapter<FlatRow, Result> rowAdapter) {
-    this.rowAdapter = rowAdapter;
-  }
-
   /**
    * adapt.
    *
@@ -58,34 +48,33 @@ public class BigtableWhileMatchResultScannerAdapter {
    *     complete. The span has an HBase specific tag, which needs to be handled by the adapter.
    * @return a {@link org.apache.hadoop.hbase.client.ResultScanner} object.
    */
-  public ResultScanner adapt(
-      final com.google.cloud.bigtable.grpc.scanner.ResultScanner<FlatRow> bigtableResultScanner,
-      final Span span) {
+  public ResultScanner adapt(final ResultScanner bigtableResultScanner, final Span span) {
     return new AbstractClientScanner() {
       @Override
       public Result next() throws IOException {
-        FlatRow row = bigtableResultScanner.next();
+        Result row = bigtableResultScanner.next();
         if (row == null) {
           // Null signals EOF.
           span.end();
           return null;
         }
 
-        if (!hasMatchingLabels(row)) {
+        Result filteredResult = externalizeResult(row);
+        if (filteredResult == null) {
           close();
           return null;
         }
 
-        return rowAdapter.adaptResponse(row);
+        return filteredResult;
       }
 
       @Override
       public void close() {
         try {
           bigtableResultScanner.close();
-        } catch (IOException ioe) {
-          span.setStatus(Status.UNKNOWN.withDescription(ioe.getMessage()));
-          throw new RuntimeException(ioe);
+        } catch (RuntimeException ex) {
+          span.setStatus(Status.UNKNOWN.withDescription(ex.getCause().getMessage()));
+          throw ex;
         } finally {
           span.end();
         }
@@ -107,29 +96,41 @@ public class BigtableWhileMatchResultScannerAdapter {
    * Returns {@code true} iff there are matching {@link WhileMatchFilter} labels or no {@link
    * WhileMatchFilter} labels.
    *
-   * @param row a {@link FlatRow} object.
+   * @param row a {@link Result} object.
    * @return a boolean value.
    */
-  public static boolean hasMatchingLabels(FlatRow row) {
+  private static Result externalizeResult(Result row) {
     int inLabelCount = 0;
     int outLabelCount = 0;
-    for (FlatRow.Cell cell : row.getCells()) {
-      for (String label : cell.getLabels()) {
-        // TODO(kevinsi4508): Make sure {@code label} is a {@link WhileMatchFilter} label.
-        // TODO(kevinsi4508): Handle multiple {@link WhileMatchFilter} labels.
-        if (label.endsWith(WHILE_MATCH_FILTER_IN_LABEL_SUFFIX)) {
-          inLabelCount++;
-        } else if (label.endsWith(WHILE_MATCH_FILTER_OUT_LABEL_SUFFIX)) {
-          outLabelCount++;
+    ImmutableList.Builder<Cell> filteredCells = ImmutableList.builder();
+
+    for (Cell cell : row.rawCells()) {
+
+      if (cell instanceof RowCell) {
+        RowCell rowCell = (RowCell) cell;
+        for (String label : rowCell.getLabels()) {
+          // TODO(kevinsi4508): Make sure {@code label} is a {@link WhileMatchFilter} label.
+          // TODO(kevinsi4508): Handle multiple {@link WhileMatchFilter} labels.
+          if (label.endsWith(WHILE_MATCH_FILTER_IN_LABEL_SUFFIX)) {
+            inLabelCount++;
+          } else if (label.endsWith(WHILE_MATCH_FILTER_OUT_LABEL_SUFFIX)) {
+            outLabelCount++;
+          }
         }
+
+        if (rowCell.getLabels().isEmpty()) {
+          filteredCells.add(rowCell);
+        }
+      } else {
+        filteredCells.add(cell);
       }
     }
 
     // Checks if there is mismatching {@link WhileMatchFilter} label.
     if (inLabelCount != outLabelCount) {
-      return false;
+      return null;
     }
 
-    return true;
+    return Result.create(filteredCells.build());
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -31,21 +31,21 @@ import static org.mockito.Mockito.when;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.bigtable.v2.ReadRowsRequest;
-import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
-import com.google.cloud.bigtable.grpc.BigtableSession;
-import com.google.cloud.bigtable.grpc.scanner.FlatRow;
-import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.adapters.read.RowCell;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.AbstractBigtableConnection;
@@ -53,6 +53,7 @@ import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.filter.BinaryComparator;
@@ -88,11 +89,11 @@ public class TestBigtableTable {
 
   @Mock private AbstractBigtableConnection mockConnection;
 
-  @Mock private BigtableSession mockSession;
+  @Mock private BigtableApi mockBigtableApi;
 
-  @Mock private IBigtableDataClient mockBigtableDataClient;
+  @Mock private DataClientWrapper mockBigtableDataClient;
 
-  @Mock private ResultScanner<FlatRow> mockResultScanner;
+  @Mock private ResultScanner mockResultScanner;
 
   public AbstractBigtableTable table;
 
@@ -112,10 +113,10 @@ public class TestBigtableTable {
     TableName tableName = TableName.valueOf(TEST_TABLE);
     HBaseRequestAdapter hbaseAdapter = new HBaseRequestAdapter(settings, tableName);
     when(mockConnection.getConfiguration()).thenReturn(config);
-    when(mockConnection.getSession()).thenReturn(mockSession);
+    when(mockConnection.getBigtableApi()).thenReturn(mockBigtableApi);
     when(mockConnection.getBigtableHBaseSettings()).thenReturn(settings);
-    when(mockSession.getDataClientWrapper()).thenReturn(mockBigtableDataClient);
-    when(mockBigtableDataClient.readFlatRows(isA(Query.class))).thenReturn(mockResultScanner);
+    when(mockBigtableApi.getDataClient()).thenReturn(mockBigtableDataClient);
+    when(mockBigtableDataClient.readRows(isA(Query.class))).thenReturn(mockResultScanner);
     table = new AbstractBigtableTable(mockConnection, hbaseAdapter) {};
   }
 
@@ -141,14 +142,16 @@ public class TestBigtableTable {
   }
 
   @Test
-  public void getRequestsAreFullyPopulated() throws IOException {
+  public void getRequestsAreFullyPopulated() throws Exception {
+    when(mockBigtableDataClient.readRowsAsync(isA(Query.class)))
+        .thenReturn(ApiFutures.immediateFuture(Collections.singletonList(Result.EMPTY_RESULT)));
     table.get(
         new Get(Bytes.toBytes("rowKey1"))
             .addColumn(Bytes.toBytes("family"), Bytes.toBytes("qualifier")));
 
     ArgumentCaptor<Query> argument = ArgumentCaptor.forClass(Query.class);
 
-    verify(mockBigtableDataClient).readFlatRowsList(argument.capture());
+    verify(mockBigtableDataClient).readRowsAsync(argument.capture());
 
     ReadRowsRequest actualRequest = argument.getValue().toProto(REQUEST_CONTEXT);
 
@@ -203,25 +206,27 @@ public class TestBigtableTable {
 
   @Test
   public void getScanner_withBigtableResultScannerAdapter() throws IOException {
-    when(mockBigtableDataClient.readFlatRows(isA(Query.class))).thenReturn(mockResultScanner);
+    when(mockBigtableDataClient.readRows(isA(Query.class))).thenReturn(mockResultScanner);
     // A row with no matching label. In case of {@link BigtableResultScannerAdapter} the result is
     // non-null.
-    FlatRow row =
-        FlatRow.newBuilder()
-            .withRowKey(ByteString.copyFromUtf8("row_key"))
-            .addCell(
-                "family_name",
-                ByteString.copyFromUtf8("q_name"),
-                0,
-                ByteString.EMPTY,
-                Arrays.asList("label-in"))
-            .addCell(
-                "family_name",
-                ByteString.copyFromUtf8("q_name"),
-                0,
-                ByteString.copyFromUtf8("value"))
-            .build();
-    when(mockResultScanner.next()).thenReturn(row);
+    Result expected =
+        Result.create(
+            ImmutableList.<Cell>of(
+                new RowCell(
+                    Bytes.toBytes("row_key"),
+                    Bytes.toBytes("family_name"),
+                    Bytes.toBytes("q_name"),
+                    0,
+                    ByteString.EMPTY.toByteArray(),
+                    Collections.singletonList("label-in")),
+                new RowCell(
+                    Bytes.toBytes("row_key"),
+                    Bytes.toBytes("family_name"),
+                    Bytes.toBytes("q_name"),
+                    0,
+                    Bytes.toBytes("value"))));
+
+    when(mockResultScanner.next()).thenReturn(expected);
 
     QualifierFilter filter =
         new QualifierFilter(CompareOp.EQUAL, new BinaryComparator(Bytes.toBytes("x")));
@@ -232,10 +237,12 @@ public class TestBigtableTable {
     assertEquals("row_key", new String(result.getRow()));
     List<org.apache.hadoop.hbase.Cell> cells =
         result.getColumnCells("family_name".getBytes(), "q_name".getBytes());
-    assertEquals(1, cells.size());
-    assertEquals("value", new String(CellUtil.cloneValue(cells.get(0))));
+    // HBase ResultScanner now allows cells with labels
+    assertEquals(2, cells.size());
+    assertEquals("", new String(CellUtil.cloneValue(cells.get(0))));
+    assertEquals("value", new String(CellUtil.cloneValue(cells.get(1))));
 
-    verify(mockBigtableDataClient).readFlatRows(isA(Query.class));
+    verify(mockBigtableDataClient).readRows(isA(Query.class));
     verify(mockResultScanner).next();
   }
 
@@ -243,12 +250,22 @@ public class TestBigtableTable {
   public void getScanner_withBigtableWhileMatchResultScannerAdapter() throws IOException {
     // A row with no matching label. In case of {@link BigtableWhileMatchResultScannerAdapter} the
     // result is null.
-    FlatRow row =
-        FlatRow.newBuilder()
-            .withRowKey(ByteString.copyFromUtf8("row_key"))
-            .addCell("", ByteString.EMPTY, 0, ByteString.EMPTY, Arrays.asList("label-in"))
-            .addCell("", ByteString.EMPTY, 0, ByteString.copyFromUtf8("value"))
-            .build();
+    Result row =
+        Result.create(
+            ImmutableList.<Cell>of(
+                new RowCell(
+                    Bytes.toBytes("row_key"),
+                    Bytes.toBytes(""),
+                    Bytes.toBytes("q_name"),
+                    0,
+                    ByteString.EMPTY.toByteArray(),
+                    Collections.singletonList("label-in")),
+                new RowCell(
+                    Bytes.toBytes("row_key"),
+                    Bytes.toBytes(""),
+                    Bytes.toBytes("q_name"),
+                    0,
+                    Bytes.toBytes("value"))));
     when(mockResultScanner.next()).thenReturn(row);
 
     QualifierFilter filter =
@@ -259,7 +276,7 @@ public class TestBigtableTable {
     org.apache.hadoop.hbase.client.ResultScanner resultScanner = table.getScanner(scan);
     assertNull(resultScanner.next());
 
-    verify(mockBigtableDataClient).readFlatRows(isA(Query.class));
+    verify(mockBigtableDataClient).readRows(isA(Query.class));
     verify(mockResultScanner).next();
   }
 


### PR DESCRIPTION
This change has followings updates:
 - Updates Data client references in `AbstractBigtableTable` and `BigtableAsyncTable`.
 - Removed label's check from FlatRowAdapter, and moved it to `BigtableWhileMatchResultScannerAdapter`.
   -  `Table#get`, `Table#getScanner`(except when whileMatchFilter is applied) would return cells with labels to user.
 - Updates `BigtableWhileMatchResultScannerAdapter` to adapt to hbase's `ResultScanner`.

Note: This is a part 3 of the series of PRs to replace references of BigtableSession/Data/Admin clients with new wrappers.