### PR TITLE
chore: replacing bulk read with bulk read wrapper (Part-5)

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -694,7 +694,8 @@ public abstract class AbstractBigtableTable implements Table {
    */
   protected synchronized BatchExecutor getBatchExecutor() {
     if (batchExecutor == null) {
-      batchExecutor = new BatchExecutor(bigtableConnection.getBigtableApi(), hbaseAdapter);
+      batchExecutor =
+          new BatchExecutor(bigtableConnection.getBigtableApi(), settings, hbaseAdapter);
     }
     return batchExecutor;
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -694,9 +694,7 @@ public abstract class AbstractBigtableTable implements Table {
    */
   protected synchronized BatchExecutor getBatchExecutor() {
     if (batchExecutor == null) {
-      batchExecutor =
-          new BatchExecutor(
-              bigtableConnection.getSession(), bigtableConnection.getBigtableApi(), hbaseAdapter);
+      batchExecutor = new BatchExecutor(bigtableConnection.getBigtableApi(), hbaseAdapter);
     }
     return batchExecutor;
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -92,14 +92,14 @@ public class BatchExecutor {
     @SuppressWarnings("unchecked")
     @Override
     public final void onSuccess(Object message) {
-      Result result = Result.EMPTY_RESULT;
-      try {
-        if (message instanceof Result) {
-          result = (Result) message;
-        }
-      } catch (Throwable throwable) {
-        onFailure(throwable);
-        return;
+      final Result result;
+
+      if (message instanceof Result) {
+        // Handle the completion of Gets
+        result = (Result) message;
+      } else {
+        // Handles the completion of other operations like Deletes & Puts that don't return anything
+        result = Result.EMPTY_RESULT;
       }
 
       resultsArray[index] = result;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -131,17 +131,17 @@ public class BatchExecutor {
   /**
    * Constructor for BatchExecutor.
    *
-   * @param bigtableApi a {@link BigtableApi} object.
-   * @param requestAdapter a {@link HBaseRequestAdapter} object.
+   * @param bigtableApi a {@link BigtableApi} object to access bigtable data client.
+   * @param settings a {@link BigtableHBaseSettings} object for bigtable settings.
+   * @param adapter a {@link HBaseRequestAdapter} object to convert HBase object to Bigtable protos.
    */
-  public BatchExecutor(BigtableApi bigtableApi, HBaseRequestAdapter requestAdapter) {
-    this.requestAdapter = requestAdapter;
-    this.settings = bigtableApi.getBigtableHBaseSettings();
+  public BatchExecutor(
+      BigtableApi bigtableApi, BigtableHBaseSettings settings, HBaseRequestAdapter adapter) {
+    this.requestAdapter = adapter;
+    this.settings = settings;
     this.bulkRead =
-        bigtableApi
-            .getDataClient()
-            .createBulkRead(requestAdapter.getBigtableTableName().getTableId());
-    this.bufferedMutatorHelper = new BigtableBufferedMutatorHelper(requestAdapter, bigtableApi);
+        bigtableApi.getDataClient().createBulkRead(adapter.getBigtableTableName().getTableId());
+    this.bufferedMutatorHelper = new BigtableBufferedMutatorHelper(bigtableApi, settings, adapter);
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -20,7 +20,6 @@ import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
 import com.google.api.core.SettableApiFuture;
-import com.google.cloud.bigtable.grpc.async.BulkRead;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
@@ -50,7 +49,7 @@ import org.apache.hadoop.hbase.util.Bytes;
  * org.apache.hadoop.hbase.client.Table#batch(List, Object[])}. {@link
  * org.apache.hadoop.hbase.client.Table#put(List)} and {@link
  * org.apache.hadoop.hbase.client.Table#get(List)}. This class relies on implementations found in
- * {@link BulkRead} and in {@link BigtableBufferedMutatorHelper}.
+ * {@link BulkReadWrapper} and in {@link BigtableBufferedMutatorHelper}.
  *
  * <p>For internal use only - public for technical reasons.
  */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -22,6 +22,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -63,17 +64,19 @@ public class BigtableBufferedMutator implements BufferedMutator {
   /**
    * Constructor for BigtableBufferedMutator.
    *
-   * @param adapter Converts HBase objects to Bigtable protos
-   * @param bigtableApi For bigtable settings and data client
+   * @param bigtableApi a {@link BigtableApi} object to access bigtable data client.
+   * @param settings a {@link BigtableHBaseSettings} object for bigtable settings.
+   * @param adapter a {@link HBaseRequestAdapter} object to convert HBase object to Bigtable protos.
    * @param listener Handles exceptions. By default, it just throws the exception.
    */
   public BigtableBufferedMutator(
-      HBaseRequestAdapter adapter,
       BigtableApi bigtableApi,
+      BigtableHBaseSettings settings,
+      HBaseRequestAdapter adapter,
       BufferedMutator.ExceptionListener listener) {
-    helper = new BigtableBufferedMutatorHelper(adapter, bigtableApi);
+    helper = new BigtableBufferedMutatorHelper(bigtableApi, settings, adapter);
     this.listener = listener;
-    this.host = bigtableApi.getBigtableHBaseSettings().getDataHost();
+    this.host = settings.getDataHost();
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutator.java
@@ -19,10 +19,9 @@ import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
-import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -65,18 +64,16 @@ public class BigtableBufferedMutator implements BufferedMutator {
    * Constructor for BigtableBufferedMutator.
    *
    * @param adapter Converts HBase objects to Bigtable protos
-   * @param settings For bigtable settings
+   * @param bigtableApi For bigtable settings and data client
    * @param listener Handles exceptions. By default, it just throws the exception.
-   * @param session a {@link BigtableSession} object.
    */
   public BigtableBufferedMutator(
       HBaseRequestAdapter adapter,
-      BigtableHBaseSettings settings,
-      BigtableSession session,
+      BigtableApi bigtableApi,
       BufferedMutator.ExceptionListener listener) {
-    helper = new BigtableBufferedMutatorHelper(adapter, settings, session);
+    helper = new BigtableBufferedMutatorHelper(adapter, bigtableApi);
     this.listener = listener;
-    this.host = settings.getDataHost();
+    this.host = bigtableApi.getBigtableHBaseSettings().getDataHost();
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -71,14 +71,16 @@ public class BigtableBufferedMutatorHelper {
   private final OperationAccountant operationAccountant;
 
   /**
-   * Constructor for BigtableBufferedMutator.
+   * Constructor for BigtableBufferedMutatorHelper.
    *
-   * @param adapter Converts HBase objects to Bigtable protos
-   * @param bigtableApi For bigtable settings and data client
+   * @param bigtableApi a {@link BigtableApi} object to access bigtable data client.
+   * @param settings a {@link BigtableHBaseSettings} object for bigtable settings
+   * @param adapter a {@link HBaseRequestAdapter} object to convert HBase objects to Bigtable protos
    */
-  public BigtableBufferedMutatorHelper(HBaseRequestAdapter adapter, BigtableApi bigtableApi) {
+  public BigtableBufferedMutatorHelper(
+      BigtableApi bigtableApi, BigtableHBaseSettings settings, HBaseRequestAdapter adapter) {
     this.adapter = adapter;
-    this.settings = bigtableApi.getBigtableHBaseSettings();
+    this.settings = settings;
     BigtableTableName tableName = this.adapter.getBigtableTableName();
     this.dataClient = bigtableApi.getDataClient();
     this.bulkMutation = dataClient.createBulkMutation(tableName.getTableId());

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -18,14 +18,14 @@ package com.google.cloud.bigtable.hbase;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.core.IBigtableDataClient;
-import com.google.cloud.bigtable.core.IBulkMutation;
-import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.util.OperationAccountant;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
 import com.google.cloud.bigtable.util.ApiFutureUtil;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -65,8 +65,8 @@ public class BigtableBufferedMutatorHelper {
   private boolean closed = false;
 
   private final HBaseRequestAdapter adapter;
-  private final IBulkMutation bulkMutation;
-  private final IBigtableDataClient dataClient;
+  private final BulkMutationWrapper bulkMutation;
+  private final DataClientWrapper dataClient;
   private final BigtableHBaseSettings settings;
   private final OperationAccountant operationAccountant;
 
@@ -74,16 +74,14 @@ public class BigtableBufferedMutatorHelper {
    * Constructor for BigtableBufferedMutator.
    *
    * @param adapter Converts HBase objects to Bigtable protos
-   * @param settings For bigtable settings
-   * @param session a {@link BigtableSession} object.
+   * @param bigtableApi For bigtable settings and data client
    */
-  public BigtableBufferedMutatorHelper(
-      HBaseRequestAdapter adapter, BigtableHBaseSettings settings, BigtableSession session) {
+  public BigtableBufferedMutatorHelper(HBaseRequestAdapter adapter, BigtableApi bigtableApi) {
     this.adapter = adapter;
-    this.settings = settings;
+    this.settings = bigtableApi.getBigtableHBaseSettings();
     BigtableTableName tableName = this.adapter.getBigtableTableName();
-    this.bulkMutation = session.createBulkMutationWrapper(tableName);
-    this.dataClient = session.getDataClientWrapper();
+    this.dataClient = bigtableApi.getDataClient();
+    this.bulkMutation = dataClient.createBulkMutation(tableName.getTableId());
     this.operationAccountant = new OperationAccountant();
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -149,7 +149,7 @@ public abstract class AbstractBigtableConnection
 
     HBaseRequestAdapter adapter = createAdapter(tableName);
     ExceptionListener listener = params.getListener();
-    return new BigtableBufferedMutator(adapter, bigtableApi, listener);
+    return new BigtableBufferedMutator(bigtableApi, settings, adapter, listener);
   }
 
   public HBaseRequestAdapter createAdapter(TableName tableName) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -149,7 +149,7 @@ public abstract class AbstractBigtableConnection
 
     HBaseRequestAdapter adapter = createAdapter(tableName);
     ExceptionListener listener = params.getListener();
-    return new BigtableBufferedMutator(adapter, settings, session, listener);
+    return new BigtableBufferedMutator(adapter, bigtableApi, listener);
   }
 
   public HBaseRequestAdapter createAdapter(TableName tableName) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -125,6 +125,7 @@ public class TestBatchExecutor {
 
   @Mock private ApiFuture mockFuture;
 
+  private BigtableHBaseSettings settings;
   private HBaseRequestAdapter requestAdapter;
 
   @Before
@@ -132,10 +133,9 @@ public class TestBatchExecutor {
     Configuration configuration = new Configuration(false);
     configuration.set(PROJECT_ID_KEY, "projectId");
     configuration.set(INSTANCE_ID_KEY, "instanceId");
-    BigtableHBaseSettings settings = BigtableHBaseSettings.create(configuration);
+    settings = BigtableHBaseSettings.create(configuration);
 
     requestAdapter = new HBaseRequestAdapter(settings, TableName.valueOf("table"));
-    when(mockBigtableApi.getBigtableHBaseSettings()).thenReturn(settings);
     when(mockBigtableApi.getDataClient()).thenReturn(mockDataClientWrapper);
     when(mockDataClientWrapper.createBulkRead("table")).thenReturn(mockBulkRead);
     when(mockDataClientWrapper.createBulkMutation(any(String.class))).thenReturn(mockBulkMutation);
@@ -353,7 +353,7 @@ public class TestBatchExecutor {
   }
 
   private BatchExecutor createExecutor() {
-    return new BatchExecutor(mockBigtableApi, requestAdapter);
+    return new BatchExecutor(mockBigtableApi, settings, requestAdapter);
   }
 
   private Result[] batch(final List<? extends org.apache.hadoop.hbase.client.Row> actions)

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -95,11 +95,10 @@ public class TestBigtableBufferedMutator {
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "instance");
 
     BigtableHBaseSettings settings = BigtableHBaseSettings.create(configuration);
-    when(mockBigtableApi.getBigtableHBaseSettings()).thenReturn(settings);
     HBaseRequestAdapter adapter = new HBaseRequestAdapter(settings, TableName.valueOf("TABLE"));
 
     executorService = Executors.newCachedThreadPool();
-    return new BigtableBufferedMutator(adapter, mockBigtableApi, listener);
+    return new BigtableBufferedMutator(mockBigtableApi, settings, adapter, listener);
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -24,14 +24,13 @@ import static org.mockito.Mockito.when;
 
 import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
-import com.google.cloud.bigtable.core.IBigtableDataClient;
-import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
-import com.google.cloud.bigtable.grpc.BigtableSession;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.BulkMutationWrapper;
+import com.google.cloud.bigtable.hbase.wrappers.DataClientWrapper;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -50,6 +49,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
@@ -63,11 +63,11 @@ public class TestBigtableBufferedMutator {
   private static final Put SIMPLE_PUT =
       new Put(EMPTY_BYTES).addColumn(EMPTY_BYTES, EMPTY_BYTES, EMPTY_BYTES);
 
-  @Mock private BigtableSession mockSession;
+  @Mock private BigtableApi mockBigtableApi;
 
-  @Mock private IBulkMutation mockBulkMutation;
+  @Mock private BulkMutationWrapper mockBulkMutation;
 
-  @Mock private IBigtableDataClient mockDataClient;
+  @Mock private DataClientWrapper mockDataClient;
 
   @SuppressWarnings("rawtypes")
   private SettableApiFuture future = SettableApiFuture.create();
@@ -78,9 +78,8 @@ public class TestBigtableBufferedMutator {
 
   @Before
   public void setUp() {
-    when(mockSession.createBulkMutationWrapper(any(BigtableTableName.class)))
-        .thenReturn(mockBulkMutation);
-    when(mockSession.getDataClientWrapper()).thenReturn(mockDataClient);
+    when(mockBigtableApi.getDataClient()).thenReturn(mockDataClient);
+    when(mockDataClient.createBulkMutation(Mockito.anyString())).thenReturn(mockBulkMutation);
   }
 
   @After
@@ -96,10 +95,11 @@ public class TestBigtableBufferedMutator {
     configuration.set(BigtableOptionsFactory.INSTANCE_ID_KEY, "instance");
 
     BigtableHBaseSettings settings = BigtableHBaseSettings.create(configuration);
+    when(mockBigtableApi.getBigtableHBaseSettings()).thenReturn(settings);
     HBaseRequestAdapter adapter = new HBaseRequestAdapter(settings, TableName.valueOf("TABLE"));
 
     executorService = Executors.newCachedThreadPool();
-    return new BigtableBufferedMutator(adapter, settings, mockSession, listener);
+    return new BigtableBufferedMutator(adapter, mockBigtableApi, listener);
   }
 
   @Test

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
@@ -21,6 +21,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.hbase.BigtableBufferedMutatorHelper;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -42,11 +43,13 @@ public class BigtableAsyncBufferedMutator implements AsyncBufferedMutator {
   /**
    * Constructor for BigtableBufferedMutator.
    *
-   * @param adapter Converts HBase objects to Bigtable protos
-   * @param bigtableApi For bigtable settings and data client.
+   * @param bigtableApi a {@link BigtableApi} object to access bigtable data client.
+   * @param settings a {@link BigtableHBaseSettings} object for bigtable settings.
+   * @param adapter a {@link HBaseRequestAdapter} object to convert HBase object to Bigtable protos.
    */
-  public BigtableAsyncBufferedMutator(HBaseRequestAdapter adapter, BigtableApi bigtableApi) {
-    helper = new BigtableBufferedMutatorHelper(adapter, bigtableApi);
+  public BigtableAsyncBufferedMutator(
+      BigtableApi bigtableApi, BigtableHBaseSettings settings, HBaseRequestAdapter adapter) {
+    helper = new BigtableBufferedMutatorHelper(bigtableApi, settings, adapter);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncBufferedMutator.java
@@ -18,10 +18,9 @@ package com.google.cloud.bigtable.hbase2_x;
 import static com.google.cloud.bigtable.hbase2_x.FutureUtils.toCompletableFuture;
 
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.hbase.BigtableBufferedMutatorHelper;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
-import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
+import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -44,12 +43,10 @@ public class BigtableAsyncBufferedMutator implements AsyncBufferedMutator {
    * Constructor for BigtableBufferedMutator.
    *
    * @param adapter Converts HBase objects to Bigtable protos
-   * @param settings For bigtable settings.
-   * @param session a {@link com.google.cloud.bigtable.grpc.BigtableSession}
+   * @param bigtableApi For bigtable settings and data client.
    */
-  public BigtableAsyncBufferedMutator(
-      HBaseRequestAdapter adapter, BigtableHBaseSettings settings, BigtableSession session) {
-    helper = new BigtableBufferedMutatorHelper(adapter, settings, session);
+  public BigtableAsyncBufferedMutator(HBaseRequestAdapter adapter, BigtableApi bigtableApi) {
+    helper = new BigtableBufferedMutatorHelper(adapter, bigtableApi);
   }
 
   /** {@inheritDoc} */

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -91,7 +91,9 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
 
   protected synchronized BatchExecutor getBatchExecutor() {
     if (batchExecutor == null) {
-      batchExecutor = new BatchExecutor(connection.getBigtableApi(), hbaseAdapter);
+      batchExecutor =
+          new BatchExecutor(
+              connection.getBigtableApi(), connection.getBigtableHBaseSettings(), hbaseAdapter);
     }
     return batchExecutor;
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -91,8 +91,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
 
   protected synchronized BatchExecutor getBatchExecutor() {
     if (batchExecutor == null) {
-      batchExecutor =
-          new BatchExecutor(connection.getSession(), connection.getBigtableApi(), hbaseAdapter);
+      batchExecutor = new BatchExecutor(connection.getBigtableApi(), hbaseAdapter);
     }
     return batchExecutor;
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -241,7 +241,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
       @Override
       public AsyncBufferedMutator build() {
-        return new BigtableAsyncBufferedMutator(createAdapter(tableName), settings, session);
+        return new BigtableAsyncBufferedMutator(createAdapter(tableName), bigtableApi);
       }
     };
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -241,7 +241,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
       @Override
       public AsyncBufferedMutator build() {
-        return new BigtableAsyncBufferedMutator(createAdapter(tableName), bigtableApi);
+        return new BigtableAsyncBufferedMutator(bigtableApi, settings, createAdapter(tableName));
       }
     };
   }


### PR DESCRIPTION
This PR contains following changes:
  - transition of data client in BigtableBufferedMutator, BufferedMutatorHelper.
  - Also BulkMutation to new wrapper.
  - updated BatchExecutor constructor to remove BigtableSession dependency.
  - remove unneeded FlatRow checks and revisited unit test for BatchExecutor.