### PR TITLE
chore: introduce point read in new Data client wrapper

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/DataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/DataClientWrapper.java
@@ -59,9 +59,6 @@ public interface DataClientWrapper extends AutoCloseable {
    */
   ApiFuture<List<KeyOffset>> sampleRowKeysAsync(String tableId);
 
-  /** Reads a single row, if the row not found then returns an empty {@link Result}. */
-  ApiFuture<Result> readRowAsync(String tableId, ByteString rowKey);
-
   /** Reads a single row based on filter, If row not found then returns an empty {@link Result}. */
   ApiFuture<Result> readRowAsync(
       String tableId, ByteString rowKey, @Nullable Filters.Filter filter);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/DataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/DataClientWrapper.java
@@ -18,12 +18,15 @@ package com.google.cloud.bigtable.hbase.wrappers;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.protobuf.ByteString;
 import io.grpc.stub.StreamObserver;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 
@@ -55,6 +58,13 @@ public interface DataClientWrapper extends AutoCloseable {
    * completed.
    */
   ApiFuture<List<KeyOffset>> sampleRowKeysAsync(String tableId);
+
+  /** Reads a single row, if the row not found then returns an empty {@link Result}. */
+  ApiFuture<Result> readRowAsync(String tableId, ByteString rowKey);
+
+  /** Reads a single row based on filter, If row not found then returns an empty {@link Result}. */
+  ApiFuture<Result> readRowAsync(
+      String tableId, ByteString rowKey, @Nullable Filters.Filter filter);
 
   /** Perform a scan over {@link Result}s, in key order. */
   ResultScanner readRows(Query request);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/DataClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/DataClientClassicApi.java
@@ -165,11 +165,6 @@ public class DataClientClassicApi implements DataClientWrapper {
   }
 
   @Override
-  public ApiFuture<Result> readRowAsync(String tableId, ByteString rowKey) {
-    return readRowAsync(tableId, rowKey, null);
-  }
-
-  @Override
   public ApiFuture<Result> readRowAsync(String tableId, ByteString rowKey, Filters.Filter filter) {
     Query request = Query.create(tableId).rowKey(rowKey).limit(1L);
     if (filter != null) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestDataClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/classic/TestDataClientClassicApi.java
@@ -350,7 +350,9 @@ public class TestDataClientClassicApi {
         .thenReturn(Futures.immediateFuture(Collections.<FlatRow>emptyList()));
 
     Result result =
-        dataClientWrapper.readRowAsync(TABLE_ID, ByteString.copyFromUtf8("non-existent-key")).get();
+        dataClientWrapper
+            .readRowAsync(TABLE_ID, ByteString.copyFromUtf8("non-existent-key"), null)
+            .get();
     assertEquals(Result.EMPTY_RESULT, result);
 
     Filters.Filter filter = Filters.FILTERS.family().exactMatch("cf");


### PR DESCRIPTION
In this change, the point reads are depending on readFlatRowsAsync(). Once the veneer client is implemented then we can set deadlines separately for this.