### PR TITLE
chore: remove references of BigtableTableName

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -139,8 +139,7 @@ public class BatchExecutor {
       BigtableApi bigtableApi, BigtableHBaseSettings settings, HBaseRequestAdapter adapter) {
     this.requestAdapter = adapter;
     this.settings = settings;
-    this.bulkRead =
-        bigtableApi.getDataClient().createBulkRead(adapter.getBigtableTableName().getTableId());
+    this.bulkRead = bigtableApi.getDataClient().createBulkRead(adapter.getTableId());
     this.bufferedMutatorHelper = new BigtableBufferedMutatorHelper(bigtableApi, settings, adapter);
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -18,7 +18,6 @@ package com.google.cloud.bigtable.hbase;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.util.OperationAccountant;
@@ -81,9 +80,8 @@ public class BigtableBufferedMutatorHelper {
       BigtableApi bigtableApi, BigtableHBaseSettings settings, HBaseRequestAdapter adapter) {
     this.adapter = adapter;
     this.settings = settings;
-    BigtableTableName tableName = this.adapter.getBigtableTableName();
     this.dataClient = bigtableApi.getDataClient();
-    this.bulkMutation = dataClient.createBulkMutation(tableName.getTableId());
+    this.bulkMutation = dataClient.createBulkMutation(this.adapter.getTableId());
     this.operationAccountant = new OperationAccountant();
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/CheckAndMutateUtil.java
@@ -212,8 +212,7 @@ public class CheckAndMutateUtil {
           "condition is null. You need to specify the condition by"
               + " calling ifNotExists/ifEquals/ifMatches before executing the request");
       ConditionalRowMutation conditionalRowMutation =
-          ConditionalRowMutation.create(
-              hbaseAdapter.getBigtableTableName().getTableId(), ByteString.copyFrom(row));
+          ConditionalRowMutation.create(hbaseAdapter.getTableId(), ByteString.copyFrom(row));
       Scan scan = new Scan();
       scan.setMaxVersions(1);
       scan.addColumn(family, qualifier);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/adapters/TestCheckAndMutateUtil.java
@@ -22,8 +22,6 @@ import com.google.bigtable.v2.Mutation;
 import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.Filters;
-import com.google.cloud.bigtable.grpc.BigtableInstanceName;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -49,8 +47,6 @@ public class TestCheckAndMutateUtil {
   private static final String PROJECT_ID = "project";
   private static final String INSTANCE_ID = "instance";
   private static final TableName TABLE_NAME = TableName.valueOf("SomeTable");
-  private static final BigtableTableName BT_TABLE_NAME =
-      new BigtableInstanceName(PROJECT_ID, INSTANCE_ID).toTableName(TABLE_NAME.getNameAsString());
   private static final RequestContext REQUEST_CONTEXT =
       RequestContext.create(PROJECT_ID, INSTANCE_ID, "SomeAppProfileId");
   private static final byte[] rowKey = Bytes.toBytes("rowKey");
@@ -72,7 +68,7 @@ public class TestCheckAndMutateUtil {
     PutAdapter putAdapter = new PutAdapter(100, true);
     HBaseRequestAdapter.MutationAdapters mutationAdapters =
         new HBaseRequestAdapter.MutationAdapters(putAdapter);
-    requestAdapter = new HBaseRequestAdapter(TABLE_NAME, BT_TABLE_NAME, mutationAdapters);
+    requestAdapter = new HBaseRequestAdapter(TABLE_NAME, mutationAdapters);
   }
 
   private static void checkPredicate(CheckAndMutateRowRequest result) {

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableAdmin.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x/src/main/java/com/google/cloud/bigtable/hbase1_x/BigtableAdmin.java
@@ -19,8 +19,8 @@ import com.google.api.core.InternalApi;
 import com.google.bigtable.admin.v2.ListSnapshotsRequest;
 import com.google.bigtable.admin.v2.ListSnapshotsResponse;
 import com.google.bigtable.admin.v2.Snapshot;
+import com.google.cloud.bigtable.admin.v2.internal.NameUtil;
 import com.google.cloud.bigtable.grpc.BigtableSnapshotName;
-import com.google.cloud.bigtable.grpc.BigtableTableName;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
@@ -150,11 +150,11 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
 
     for (Snapshot snapshot : snapshotList.getSnapshotsList()) {
       BigtableSnapshotName snapshotName = new BigtableSnapshotName(snapshot.getName());
-      BigtableTableName tableName = new BigtableTableName(snapshot.getSourceTable().getName());
+      String tableName = snapshot.getSourceTable().getName();
       response.add(
           HBaseProtos.SnapshotDescription.newBuilder()
               .setName(snapshotName.getSnapshotId())
-              .setTable(tableName.getTableId())
+              .setTable(NameUtil.extractTableIdFromTableName(tableName))
               .setCreationTime(TimeUnit.SECONDS.toMillis(snapshot.getCreateTime().getSeconds()))
               .build());
     }


### PR DESCRIPTION
This change replaces references of `BigtableTableName.java` with string tableId.

Once this PR is merged only `bigtable-hbase`'s ``..wrapper.classic` package will contain references of this class outside of core module.