### PR TITLE
chore: update BulkReadWrapper surface to accept rowKey and filter

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -22,6 +22,7 @@ import com.google.api.core.InternalApi;
 import com.google.api.core.SettableApiFuture;
 import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
+import com.google.cloud.bigtable.hbase.util.ByteStringer;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
@@ -31,7 +32,6 @@ import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.cloud.bigtable.metrics.Timer;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -172,7 +172,7 @@ public class BatchExecutor {
     try {
       if (row instanceof Get) {
         return bulkRead.add(
-            ByteString.copyFrom(row.getRow()), Adapters.GET_ADAPTER.buildFilter((Get) row));
+            ByteStringer.wrap(row.getRow()), Adapters.GET_ADAPTER.buildFilter((Get) row));
       } else if (row instanceof Mutation) {
         return bufferedMutatorHelper.mutate((Mutation) row);
       } else if (row instanceof RowMutations) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BatchExecutor.java
@@ -20,6 +20,7 @@ import com.google.api.core.ApiFutureCallback;
 import com.google.api.core.ApiFutures;
 import com.google.api.core.InternalApi;
 import com.google.api.core.SettableApiFuture;
+import com.google.cloud.bigtable.hbase.adapters.Adapters;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
 import com.google.cloud.bigtable.hbase.util.Logger;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
@@ -30,6 +31,7 @@ import com.google.cloud.bigtable.metrics.BigtableClientMetrics.MetricLevel;
 import com.google.cloud.bigtable.metrics.Timer;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -169,7 +171,8 @@ public class BatchExecutor {
   private ApiFuture<?> issueAsyncRequest(Row row) {
     try {
       if (row instanceof Get) {
-        return bulkRead.add(requestAdapter.adapt((Get) row));
+        return bulkRead.add(
+            ByteString.copyFrom(row.getRow()), Adapters.GET_ADAPTER.buildFilter((Get) row));
       } else if (row instanceof Mutation) {
         return bufferedMutatorHelper.mutate((Mutation) row);
       } else if (row instanceof RowMutations) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/GetAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/GetAdapter.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.hbase.adapters.read;
 
 import com.google.api.core.InternalApi;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.protobuf.ByteString;
 import org.apache.hadoop.hbase.client.Get;
@@ -61,6 +62,19 @@ public class GetAdapter implements ReadOperationAdapter<Get> {
     query
         .filter(scanAdapter.buildFilter(operationAsScan, readHooks))
         .rowKey(ByteString.copyFrom(operation.getRow()));
+  }
+
+  /**
+   * creates filter based on user provided conditions in {@link Get} request.
+   *
+   * @param operation a {@link Get} object.
+   * @return a {@link Filters.Filter} object.
+   */
+  public Filters.Filter buildFilter(Get operation) {
+    Scan operationAsScan = new Scan(addKeyOnlyFilter(operation));
+    scanAdapter.throwIfUnsupportedScan(operationAsScan);
+
+    return scanAdapter.buildFilter(operationAsScan, new DefaultReadHooks());
   }
 
   private Get addKeyOnlyFilter(Get get) {

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkReadWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BulkReadWrapper.java
@@ -17,8 +17,10 @@ package com.google.cloud.bigtable.hbase.wrappers;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.InternalApi;
-import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Filters;
+import com.google.protobuf.ByteString;
 import java.io.IOException;
+import javax.annotation.Nullable;
 import org.apache.hadoop.hbase.client.Result;
 
 /**
@@ -30,10 +32,10 @@ import org.apache.hadoop.hbase.client.Result;
 public interface BulkReadWrapper extends AutoCloseable {
 
   /**
-   * Adds the key in the request to a batch read. The future will be resolved when the batch
-   * response is received.
+   * Adds a {@code rowKey} to a batch read row request with an optional {@link Filters.Filter}. The
+   * returned future will be resolved when the batch response is received.
    */
-  ApiFuture<Result> add(Query query);
+  ApiFuture<Result> add(ByteString rowKey, @Nullable Filters.Filter filter);
 
   /**
    * Sends all remaining requests to the server. This method does not wait for the method to

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/DataClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/DataClientClassicApi.java
@@ -92,7 +92,7 @@ public class DataClientClassicApi implements DataClientWrapper {
         new BigtableTableName(
             NameUtil.formatTableName(
                 requestContext.getProjectId(), requestContext.getInstanceId(), tableId));
-    return new BulkReadClassicApi(session.createBulkRead(tableName));
+    return new BulkReadClassicApi(session.createBulkRead(tableName), tableId);
   }
 
   @Override

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -30,7 +30,7 @@ import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
-import com.google.cloud.bigtable.data.v2.models.Query;
+import com.google.cloud.bigtable.data.v2.models.Filters;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutationEntry;
 import com.google.cloud.bigtable.hbase.adapters.HBaseRequestAdapter;
@@ -158,7 +158,7 @@ public class TestBatchExecutor {
 
   @Test
   public void testGet() throws Exception {
-    when(mockBulkRead.add(any(Query.class))).thenReturn(mockFuture);
+    when(mockBulkRead.add(any(ByteString.class), any(Filters.Filter.class))).thenReturn(mockFuture);
     final byte[] key = randomBytes(8);
     Result response =
         Result.create(
@@ -240,7 +240,7 @@ public class TestBatchExecutor {
                     Bytes.toBytes("hi!"),
                     ImmutableList.<String>of())));
     RuntimeException exception = new RuntimeException("Something bad happened");
-    when(mockBulkRead.add(any(Query.class)))
+    when(mockBulkRead.add(any(ByteString.class), any(Filters.Filter.class)))
         .thenReturn(ApiFutures.immediateFuture(expected))
         .thenReturn(ApiFutures.<Result>immediateFailedFuture(exception));
 
@@ -258,7 +258,7 @@ public class TestBatchExecutor {
 
   @Test
   public void testGetCallback() throws Exception {
-    when(mockBulkRead.add(any(Query.class))).thenReturn(mockFuture);
+    when(mockBulkRead.add(any(ByteString.class), any(Filters.Filter.class))).thenReturn(mockFuture);
     byte[] key = randomBytes(8);
     Result response =
         Result.create(
@@ -302,7 +302,7 @@ public class TestBatchExecutor {
     }
 
     // Test 10 gets, but return only 9 to test the row not found case.
-    when(mockBulkRead.add(any(Query.class)))
+    when(mockBulkRead.add(any(ByteString.class), any(Filters.Filter.class)))
         .then(
             new Answer<ApiFuture<Result>>() {
               final AtomicInteger counter = new AtomicInteger();
@@ -326,7 +326,7 @@ public class TestBatchExecutor {
     when(mockFuture.get()).thenReturn(row);
 
     Result[] results = createExecutor().batch(gets);
-    verify(mockBulkRead, times(10)).add(any(Query.class));
+    verify(mockBulkRead, times(10)).add(any(ByteString.class), any(Filters.Filter.class));
     verify(mockBulkRead, times(1)).flush();
     assertTrue(matchesRow(Result.EMPTY_RESULT).matches(results[0]));
     for (int i = 1; i < results.length; i++) {


### PR DESCRIPTION
`BulkRead` expects one rowKey as an entry and an optional filter field within a Query instance. Currently, we have to convert Query to proto type to verify fields. With this PR BulkRead will now accept rowKey and filter.