### PR TITLE
chore(cleanup): remove references of BigtableSession

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/AdminClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/AdminClientWrapper.java
@@ -20,6 +20,7 @@ import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
 import com.google.cloud.bigtable.admin.v2.models.ModifyColumnFamiliesRequest;
 import com.google.cloud.bigtable.admin.v2.models.Table;
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -53,4 +54,7 @@ public interface AdminClientWrapper extends AutoCloseable {
 
   /** Asynchronously drops all data in the table */
   ApiFuture<Void> dropAllRowsAsync(String tableId);
+
+  @Override
+  void close() throws IOException;
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/BigtableApi.java
@@ -50,4 +50,7 @@ public abstract class BigtableApi implements AutoCloseable {
   public BigtableHBaseSettings getBigtableHBaseSettings() {
     return hBaseSettings;
   }
+
+  @Override
+  public abstract void close() throws IOException;
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/DataClientWrapper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/DataClientWrapper.java
@@ -25,6 +25,7 @@ import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
 import com.google.protobuf.ByteString;
 import io.grpc.stub.StreamObserver;
+import java.io.IOException;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.hadoop.hbase.client.Result;
@@ -71,4 +72,7 @@ public interface DataClientWrapper extends AutoCloseable {
 
   /** Read {@link Result} asynchronously, and pass them to a stream observer to be processed. */
   void readRowsAsync(Query request, StreamObserver<Result> observer);
+
+  @Override
+  void close() throws IOException;
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/BigtableClassicApi.java
@@ -68,7 +68,7 @@ public class BigtableClassicApi extends BigtableApi {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() throws IOException {
     if (adminClientWrapper != null) {
       adminClientWrapper.close();
     }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/DataClientClassicApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/classic/DataClientClassicApi.java
@@ -262,7 +262,7 @@ public class DataClientClassicApi implements DataClientWrapper {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() throws IOException {
     session.close();
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/AdminClientVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/AdminClientVeneerApi.java
@@ -70,7 +70,7 @@ public class AdminClientVeneerApi implements AdminClientWrapper {
   }
 
   @Override
-  public void close() throws Exception {
+  public void close() {
     delegate.close();
   }
 }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/wrappers/veneer/BulkReadVeneerApi.java
@@ -18,6 +18,7 @@ package com.google.cloud.bigtable.hbase.wrappers.veneer;
 import com.google.api.core.ApiFunction;
 import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiFutures;
+import com.google.api.core.InternalApi;
 import com.google.api.gax.batching.Batcher;
 import com.google.bigtable.v2.RowFilter;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
@@ -39,8 +40,11 @@ import org.apache.hadoop.hbase.client.Result;
  * <p>This class works with {@link com.google.cloud.bigtable.hbase.BatchExecutor} to enable bulk
  * reads from the hbase api.
  *
- * <p>This class is not thread safe. It must be used on a single thread
+ * <p>This class is not thread safe. It must be used on a single thread.
+ *
+ * <p>For internal use only - public for technical reasons.
  */
+@InternalApi("For internal usage only")
 public class BulkReadVeneerApi implements BulkReadWrapper {
 
   private final BigtableDataClient client;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/CommonConnection.java
@@ -17,7 +17,6 @@ package org.apache.hadoop.hbase.client;
 
 import com.google.api.core.InternalApi;
 import com.google.cloud.bigtable.config.BigtableOptions;
-import com.google.cloud.bigtable.grpc.BigtableSession;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableApi;
 import com.google.cloud.bigtable.hbase.wrappers.BigtableHBaseSettings;
 import java.io.Closeable;
@@ -35,10 +34,6 @@ import org.apache.hadoop.hbase.TableName;
  */
 @InternalApi("For internal usage only")
 public interface CommonConnection extends Closeable {
-
-  /** @deprecated Please use {@link #getBigtableApi()}. */
-  @Deprecated
-  BigtableSession getSession();
 
   /** Returns {@link BigtableApi} object to access bigtable data and admin client APIs. */
   BigtableApi getBigtableApi();

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/wrappers/veneer/TestBulkReadVeneerApi.java
@@ -46,6 +46,7 @@ public class TestBulkReadVeneerApi {
   private static final String TABLE_ID = "fake-table-id";
   private FakeDataService fakeDataService = new FakeDataService();
   private BigtableDataSettings.Builder settingsBuilder;
+  private Server server;
 
   @Before
   public void setUp() throws IOException {
@@ -54,13 +55,21 @@ public class TestBulkReadVeneerApi {
       port = s.getLocalPort();
     }
 
-    Server server = ServerBuilder.forPort(port).addService(fakeDataService).build();
+    server = ServerBuilder.forPort(port).addService(fakeDataService).build();
     server.start();
 
     settingsBuilder =
         BigtableDataSettings.newBuilderForEmulator(port)
             .setProjectId("fake-project")
             .setInstanceId("fake-instance");
+  }
+
+  @Test
+  public void tearDown() throws InterruptedException {
+    if (server != null) {
+      server.shutdown();
+      server.awaitTermination();
+    }
   }
 
   @Test


### PR DESCRIPTION
This PR removes `BigtableSession` getter from `CommonConnection` and its references.